### PR TITLE
Changes so File object creation doesn't violate on of the MUSTs

### DIFF
--- a/stix2/__init__.py
+++ b/stix2/__init__.py
@@ -8,7 +8,7 @@ from .observables import (URL, Artifact, AutonomousSystem, Directory,
                           DomainName, EmailAddress, EmailMessage, EmailMIMEComponent, File,
                           IPv4Address, IPv6Address, MACAddress, Mutex,
                           NetworkTraffic, Process, Software, UserAccount,
-                          WindowsRegistryKey, X509Certificate)
+                          WindowsRegistryKey, WindowsRegistryValueType, X509Certificate)
 from .other import (ExternalReference, GranularMarking, KillChainPhase,
                     MarkingDefinition, StatementMarking, TLPMarking)
 from .sdo import (AttackPattern, Campaign, CourseOfAction, Identity, Indicator,

--- a/stix2/__init__.py
+++ b/stix2/__init__.py
@@ -5,7 +5,7 @@
 from . import exceptions
 from .bundle import Bundle
 from .observables import (URL, Artifact, AutonomousSystem, Directory,
-                          DomainName, EmailAddress, EmailMessage, File,
+                          DomainName, EmailAddress, EmailMessage, EmailMIMEComponent, File,
                           IPv4Address, IPv6Address, MACAddress, Mutex,
                           NetworkTraffic, Process, Software, UserAccount,
                           WindowsRegistryKey, X509Certificate)

--- a/stix2/exceptions.py
+++ b/stix2/exceptions.py
@@ -90,16 +90,44 @@ class UnmodifiablePropertyError(STIXError, ValueError):
         return msg.format(", ".join(self.unchangable_properties))
 
 
-class ObjectConstraintError(STIXError, TypeError):
-    """Violating some interproperty constraint of a STIX object type."""
+class MutuallyExclusivePropertiesError(STIXError, TypeError):
+    """Violating interproperty mutually exclusive constraint of a STIX object type."""
 
     def __init__(self, cls, fields):
-        super(ObjectConstraintError, self).__init__()
+        super(MutuallyExclusivePropertiesError, self).__init__()
         self.cls = cls
         self.fields = sorted(list(fields))
 
     def __str__(self):
-        msg = "The field(s) for {0}: ({1}) are not consistent."
+        msg = "The field(s) for {0}: ({1}) are mutually exclusive."
+        return msg.format(self.cls.__name__,
+                          ", ".join(x for x in self.fields))
+
+
+class DependentPropertiestError(STIXError, TypeError):
+    """Violating interproperty dependency constraint of a STIX object type."""
+
+    def __init__(self, cls, dependencies):
+        super(DependentPropertiestError, self).__init__()
+        self.cls = cls
+        self.dependencies = dependencies
+
+    def __str__(self):
+        msg = "The property dependencies for {0}: ({1}) are not met."
+        return msg.format(self.cls.__name__,
+                          ", ".join(x for x in self.dependencies))
+
+
+class AtLeastOnePropertyError(STIXError, TypeError):
+    """Violating a constraint of a STIX object type that at least one of the given properties must be populated."""
+
+    def __init__(self, cls, fields):
+        super(AtLeastOnePropertyError, self).__init__()
+        self.cls = cls
+        self.fields = sorted(list(fields))
+
+    def __str__(self):
+        msg = "At least one of the field(s) for {0}: ({1}) must be populated."
         return msg.format(self.cls.__name__,
                           ", ".join(x for x in self.fields))
 

--- a/stix2/observables.py
+++ b/stix2/observables.py
@@ -6,7 +6,6 @@ and do not have a '_type' attribute.
 """
 
 from .base import Observable, _STIXBase
-from .exceptions import ObjectConstraintError
 from .properties import (BinaryProperty, BooleanProperty, DictionaryProperty,
                          EmbeddedObjectProperty, HashesProperty, HexProperty,
                          IntegerProperty, ListProperty,
@@ -23,6 +22,11 @@ class Artifact(Observable):
         'url': StringProperty(),
         'hashes': HashesProperty(),
     }
+
+    def _check_object_constaints(self):
+        super(Artifact, self)._check_object_constaints()
+        self._check_mutually_exclusive_properties(["payload_bin", "url"])
+        self._check_properties_dependency(["hashes"], ["url"])
 
 
 class AutonomousSystem(Observable):
@@ -76,6 +80,10 @@ class EmailMIMEComponent(_STIXBase):
         'content_disposition': StringProperty(),
     }
 
+    def _check_object_constaints(self):
+        super(EmailMIMEComponent, self)._check_object_constaints()
+        self._check_at_least_one_property(["body", "body_raw_ref"])
+
 
 class EmailMessage(Observable):
     _type = 'email-message'
@@ -96,6 +104,11 @@ class EmailMessage(Observable):
         'body_multipart': ListProperty(EmbeddedObjectProperty(type=EmailMIMEComponent)),
         'raw_email_ref': ObjectReferenceProperty(),
     }
+
+    def _check_object_constaints(self):
+        super(EmailMessage, self)._check_object_constaints()
+        self._check_properties_dependency(["is_multipart"], ["body_multipart"])
+        # self._dependency(["is_multipart"], ["body"], [False])
 
 
 class File(Observable):
@@ -123,15 +136,8 @@ class File(Observable):
 
     def _check_object_constaints(self):
         super(File, self)._check_object_constaints()
-        illegal_properties = []
-        current_properties = self.properties_populated()
-        if not self.is_encrypted:
-            for p in ["encryption_algorithm", "decryption_key"]:
-                if p in current_properties:
-                    illegal_properties.append(p)
-        if illegal_properties:
-            illegal_properties.append("is_encrypted")
-            raise ObjectConstraintError(self.__class__, illegal_properties)
+        self._check_properties_dependency(["is_encrypted"], ["encryption_algorithm", "decryption_key"])
+        self._check_at_least_one_property(["hashes", "name"])
 
 
 class IPv4Address(Observable):
@@ -182,7 +188,7 @@ class NetworkTraffic(Observable):
         'dst_ref': ObjectReferenceProperty(),
         'src_port': IntegerProperty(),
         'dst_port': IntegerProperty(),
-        'protocols': ListProperty(StringProperty),
+        'protocols': ListProperty(StringProperty, required=True),
         'src_byte_count': IntegerProperty(),
         'dst_byte_count': IntegerProperty(),
         'src_packets': IntegerProperty(),
@@ -193,6 +199,10 @@ class NetworkTraffic(Observable):
         'encapsulates_refs': ListProperty(ObjectReferenceProperty),
         'encapsulates_by_ref': ObjectReferenceProperty(),
     }
+
+    def _check_object_constaints(self):
+        super(NetworkTraffic, self)._check_object_constaints()
+        self._check_at_least_one_property(["src_ref", "dst_ref"])
 
 
 class Process(Observable):
@@ -279,6 +289,32 @@ class WindowsRegistryKey(Observable):
         'number_of_subkeys': IntegerProperty(),
     }
 
+    @property
+    def values(self):
+        return self._inner['values']
+
+
+class X509V3ExtenstionsType(_STIXBase):
+    _type = 'x509-v3-extensions-type'
+    _properties = {
+        'basic_constraints': StringProperty(),
+        'name_constraints': StringProperty(),
+        'policy_constraints': StringProperty(),
+        'key_usage': StringProperty(),
+        'extended_key_usage': StringProperty(),
+        'subject_key_identifier': StringProperty(),
+        'authority_key_identifier': StringProperty(),
+        'subject_alternative_name': StringProperty(),
+        'issuer_alternative_name': StringProperty(),
+        'subject_directory_attributes': StringProperty(),
+        'crl_distribution_points': StringProperty(),
+        'inhibit_any_policy': StringProperty(),
+        'private_key_usage_period_not_before': TimestampProperty(),
+        'private_key_usage_period_not_after': TimestampProperty(),
+        'certificate_policies': StringProperty(),
+        'policy_mappings': StringProperty(),
+    }
+
 
 class X509Certificate(Observable):
     _type = 'x509-certificate'
@@ -296,5 +332,5 @@ class X509Certificate(Observable):
         'subject_public_key_algorithm': StringProperty(),
         'subject_public_key_modulus': StringProperty(),
         'subject_public_key_exponent': IntegerProperty(),
-        'x509_v3_extensions': Property(),
+        'x509_v3_extensions': EmbeddedObjectProperty(type=X509V3ExtenstionsType),
     }

--- a/stix2/observables.py
+++ b/stix2/observables.py
@@ -9,7 +9,7 @@ from .base import _Observable, _STIXBase
 from .properties import (BinaryProperty, BooleanProperty, DictionaryProperty,
                          EmbeddedObjectProperty, EnumProperty, HashesProperty,
                          HexProperty, IntegerProperty, ListProperty,
-                         ObjectReferenceProperty, Property, StringProperty,
+                         ObjectReferenceProperty, StringProperty,
                          TimestampProperty, TypeProperty)
 
 
@@ -305,9 +305,9 @@ class WindowsRegistryKey(_Observable):
 
     @property
     def values(self):
-      # Needed because 'values' is a property on collections.Mapping objects
+        # Needed because 'values' is a property on collections.Mapping objects
         return self._inner['values']
-      
+
 
 class X509V3ExtenstionsType(_STIXBase):
     _type = 'x509-v3-extensions-type'
@@ -329,7 +329,7 @@ class X509V3ExtenstionsType(_STIXBase):
         'certificate_policies': StringProperty(),
         'policy_mappings': StringProperty(),
     }
-    
+
 
 class X509Certificate(_Observable):
     _type = 'x509-certificate'

--- a/stix2/test/test_observed_data.py
+++ b/stix2/test/test_observed_data.py
@@ -587,7 +587,7 @@ def test_software_example():
     assert s.version == "2002"
     assert s.vendor == "Microsoft"
 
-    
+
 def test_url_example():
     s = stix2.URL(value="https://example.com/research/index.html")
 
@@ -619,8 +619,8 @@ def test_user_account_example():
     assert a.password_last_changed == dt.datetime(2016, 1, 20, 14, 27, 43, tzinfo=pytz.utc)
     assert a.account_first_login == dt.datetime(2016, 1, 20, 14, 26, 7, tzinfo=pytz.utc)
     assert a.account_last_login == dt.datetime(2016, 7, 22, 16, 8, 28, tzinfo=pytz.utc)
-    
-    
+
+
 def test_windows_registry_key_example():
     with pytest.raises(ValueError):
         v = stix2.WindowsRegistryValueType(name="Foo",
@@ -648,4 +648,3 @@ def test_x509_certificate_example():
     assert x509.type == "x509-certificate"
     assert x509.issuer == "C=ZA, ST=Western Cape, L=Cape Town, O=Thawte Consulting cc, OU=Certification Services Division, CN=Thawte Server CA/emailAddress=server-certs@thawte.com"  # noqa
     assert x509.subject == "C=US, ST=Maryland, L=Pasadena, O=Brent Baccala, OU=FreeSoft, CN=www.freesoft.org/emailAddress=baccala@freesoft.org"  # noqa
-


### PR DESCRIPTION
Added three new exceptions: DependentPropertiestError, AtLeastOnePropertyError, MutuallyExclusivePropertiesError
Added tests for NetworkTraffic, Process, URL, WindowsRegistryKey and X509Certificate
Added error tests for EmailMessage, NetworkTraffic, Artifact,
Added interproperty checker methods to the base class:  _check_mutually_exclusive_properties, _check_at_least_one_property and _check_properties_dependency
Added interproperty checkers to Artifact, EmailMIMEComponent, EmailMessage, NetworkTraffic
Made NetworkTraffic.protocols required
Added X509V3ExtenstionsType class
Use EmbeddedObjectProperty for X509Certificate.x509_v3_extensions