### PR TITLE
Refactor Observables code for issue #23

### DIFF
--- a/stix2/__init__.py
+++ b/stix2/__init__.py
@@ -5,22 +5,24 @@
 from . import exceptions
 from .bundle import Bundle
 from .observables import (URL, AlternateDataStream, ArchiveExt, Artifact,
-                          AutonomousSystem, Directory, DomainName,
-                          EmailAddress, EmailMessage, EmailMIMEComponent, File,
-                          HTTPRequestExt, ICMPExt, IPv4Address, IPv6Address,
-                          MACAddress, Mutex, NetworkTraffic, NTFSExt, PDFExt,
-                          Process, RasterImageExt, SocketExt, Software, TCPExt,
+                          AutonomousSystem, CustomObservable, Directory,
+                          DomainName, EmailAddress, EmailMessage,
+                          EmailMIMEComponent, File, HTTPRequestExt, ICMPExt,
+                          IPv4Address, IPv6Address, MACAddress, Mutex,
+                          NetworkTraffic, NTFSExt, PDFExt, Process,
+                          RasterImageExt, SocketExt, Software, TCPExt,
                           UNIXAccountExt, UserAccount, WindowsPEBinaryExt,
                           WindowsPEOptionalHeaderType, WindowsPESection,
                           WindowsProcessExt, WindowsRegistryKey,
                           WindowsRegistryValueType, WindowsServiceExt,
-                          X509Certificate, X509V3ExtenstionsType)
+                          X509Certificate, X509V3ExtenstionsType,
+                          parse_observable)
 from .other import (TLP_AMBER, TLP_GREEN, TLP_RED, TLP_WHITE,
                     ExternalReference, GranularMarking, KillChainPhase,
                     MarkingDefinition, StatementMarking, TLPMarking)
-from .sdo import (AttackPattern, Campaign, CourseOfAction, Identity, Indicator,
-                  IntrusionSet, Malware, ObservedData, Report, ThreatActor,
-                  Tool, Vulnerability)
+from .sdo import (AttackPattern, Campaign, CourseOfAction, CustomObject,
+                  Identity, Indicator, IntrusionSet, Malware, ObservedData,
+                  Report, ThreatActor, Tool, Vulnerability)
 from .sro import Relationship, Sighting
 from .utils import get_dict
 from .version import __version__
@@ -41,59 +43,6 @@ OBJ_MAP = {
     'tool': Tool,
     'sighting': Sighting,
     'vulnerability': Vulnerability,
-}
-
-OBJ_MAP_OBSERVABLE = {
-    'artifact': Artifact,
-    'autonomous-system': AutonomousSystem,
-    'directory': Directory,
-    'domain-name': DomainName,
-    'email-address': EmailAddress,
-    'email-message': EmailMessage,
-    'file': File,
-    'ipv4-addr': IPv4Address,
-    'ipv6-addr': IPv6Address,
-    'mac-addr': MACAddress,
-    'mutex': Mutex,
-    'network-traffic': NetworkTraffic,
-    'process': Process,
-    'software': Software,
-    'url': URL,
-    'user-account': UserAccount,
-    'windows-registry-key': WindowsRegistryKey,
-    'x509-certificate': X509Certificate,
-}
-
-EXT_MAP_FILE = {
-    'archive-ext': ArchiveExt,
-    'ntfs-ext': NTFSExt,
-    'pdf-ext': PDFExt,
-    'raster-image-ext': RasterImageExt,
-    'windows-pebinary-ext': WindowsPEBinaryExt
-}
-
-EXT_MAP_NETWORK_TRAFFIC = {
-    'http-request-ext': HTTPRequestExt,
-    'icmp-ext': ICMPExt,
-    'socket-ext': SocketExt,
-    'tcp-ext': TCPExt,
-}
-
-EXT_MAP_PROCESS = {
-    'windows-process-ext': WindowsProcessExt,
-    'windows-service-ext': WindowsServiceExt,
-}
-
-EXT_MAP_USER_ACCOUNT = {
-    'unix-account-ext': UNIXAccountExt,
-}
-
-EXT_MAP = {
-    'file': EXT_MAP_FILE,
-    'network-traffic': EXT_MAP_NETWORK_TRAFFIC,
-    'process': EXT_MAP_PROCESS,
-    'user-account': EXT_MAP_USER_ACCOUNT,
-
 }
 
 
@@ -120,47 +69,8 @@ def parse(data, allow_custom=False):
     return obj_class(allow_custom=allow_custom, **obj)
 
 
-def parse_observable(data, _valid_refs=[], allow_custom=False):
-    """Deserialize a string or file-like object into a STIX Cyber Observable object.
-
-    Args:
-        data: The STIX 2 string to be parsed.
-        _valid_refs: A list of object references valid for the scope of the object being parsed.
-        allow_custom: Whether to allow custom properties or not. Default: False.
-
-    Returns:
-        An instantiated Python STIX Cyber Observable object.
-    """
-
-    obj = get_dict(data)
-    obj['_valid_refs'] = _valid_refs
-
-    if 'type' not in obj:
-        raise exceptions.ParseError("Can't parse object with no 'type' property: %s" % str(obj))
-    try:
-        obj_class = OBJ_MAP_OBSERVABLE[obj['type']]
-    except KeyError:
-        raise exceptions.ParseError("Can't parse unknown object type '%s'! For custom observables, use the CustomObservable decorator." % obj['type'])
-
-    if 'extensions' in obj and obj['type'] in EXT_MAP:
-        for name, ext in obj['extensions'].items():
-            if name not in EXT_MAP[obj['type']]:
-                raise exceptions.ParseError("Can't parse Unknown extension type '%s' for object type '%s'!" % (name, obj['type']))
-            ext_class = EXT_MAP[obj['type']][name]
-            obj['extensions'][name] = ext_class(allow_custom=allow_custom, **obj['extensions'][name])
-
-    return obj_class(allow_custom=allow_custom, **obj)
-
-
 def _register_type(new_type):
     """Register a custom STIX Object type.
     """
 
     OBJ_MAP[new_type._type] = new_type
-
-
-def _register_observable(new_observable):
-    """Register a custom STIX Cyber Observable type.
-    """
-
-    OBJ_MAP_OBSERVABLE[new_observable._type] = new_observable

--- a/stix2/sdo.py
+++ b/stix2/sdo.py
@@ -4,9 +4,10 @@ import stix2
 
 from .base import _STIXBase
 from .common import COMMON_PROPERTIES
+from .observables import ObservableProperty
 from .other import KillChainPhase
 from .properties import (IDProperty, IntegerProperty, ListProperty,
-                         ObservableProperty, ReferenceProperty, StringProperty,
+                         ReferenceProperty, StringProperty,
                          TimestampProperty, TypeProperty)
 from .utils import NOW
 

--- a/stix2/sdo.py
+++ b/stix2/sdo.py
@@ -7,8 +7,8 @@ from .common import COMMON_PROPERTIES
 from .observables import ObservableProperty
 from .other import KillChainPhase
 from .properties import (IDProperty, IntegerProperty, ListProperty,
-                         ReferenceProperty, StringProperty,
-                         TimestampProperty, TypeProperty)
+                         ReferenceProperty, StringProperty, TimestampProperty,
+                         TypeProperty)
 from .utils import NOW
 
 

--- a/stix2/test/test_custom.py
+++ b/stix2/test/test_custom.py
@@ -166,3 +166,15 @@ def test_observable_custom_property_allowed():
         allow_custom=True,
     )
     assert no.x_foo == "bar"
+
+
+def test_observed_data_with_custom_observable_object():
+    no = NewObservable(property1='something')
+    ob_data = stix2.ObservedData(
+        first_observed=stix2.utils.NOW,
+        last_observed=stix2.utils.NOW,
+        number_observed=1,
+        objects={'0': no},
+        allow_custom=True,
+    )
+    assert ob_data.objects['0'].property1 == 'something'

--- a/stix2/test/test_custom.py
+++ b/stix2/test/test_custom.py
@@ -2,6 +2,8 @@ import pytest
 
 import stix2
 
+from .constants import FAKE_TIME
+
 
 def test_identity_custom_property():
     with pytest.raises(ValueError):
@@ -171,8 +173,8 @@ def test_observable_custom_property_allowed():
 def test_observed_data_with_custom_observable_object():
     no = NewObservable(property1='something')
     ob_data = stix2.ObservedData(
-        first_observed=stix2.utils.NOW,
-        last_observed=stix2.utils.NOW,
+        first_observed=FAKE_TIME,
+        last_observed=FAKE_TIME,
         number_observed=1,
         objects={'0': no},
         allow_custom=True,

--- a/stix2/test/test_properties.py
+++ b/stix2/test/test_properties.py
@@ -2,10 +2,10 @@ import pytest
 
 from stix2 import TCPExt
 from stix2.exceptions import AtLeastOnePropertyError, DictionaryKeyError
-from stix2.observables import EmailMIMEComponent
+from stix2.observables import EmailMIMEComponent, ExtensionsProperty
 from stix2.properties import (BinaryProperty, BooleanProperty,
                               DictionaryProperty, EmbeddedObjectProperty,
-                              EnumProperty, ExtensionsProperty, HashesProperty,
+                              EnumProperty, HashesProperty,
                               HexProperty, IDProperty, IntegerProperty,
                               ListProperty, Property, ReferenceProperty,
                               StringProperty, TimestampProperty, TypeProperty)

--- a/stix2/test/test_properties.py
+++ b/stix2/test/test_properties.py
@@ -5,10 +5,10 @@ from stix2.exceptions import AtLeastOnePropertyError, DictionaryKeyError
 from stix2.observables import EmailMIMEComponent, ExtensionsProperty
 from stix2.properties import (BinaryProperty, BooleanProperty,
                               DictionaryProperty, EmbeddedObjectProperty,
-                              EnumProperty, HashesProperty,
-                              HexProperty, IDProperty, IntegerProperty,
-                              ListProperty, Property, ReferenceProperty,
-                              StringProperty, TimestampProperty, TypeProperty)
+                              EnumProperty, HashesProperty, HexProperty,
+                              IDProperty, IntegerProperty, ListProperty,
+                              Property, ReferenceProperty, StringProperty,
+                              TimestampProperty, TypeProperty)
 
 from .constants import FAKE_TIME
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,9 @@ max-line-length=160
 
 [testenv:isort-check]
 deps = isort
-commands = isort -rc stix2 examples -c -df
+commands =
+    isort -rc stix2 examples -df
+    isort -rc stix2 examples -c
 
 [travis]
 python =


### PR DESCRIPTION
Move ObservableProperty, ExtensionsProperty, and Observable parsing code into observables.py to prevent circular imports and fix #23.