### PR TITLE
Fix timestamp constant

### DIFF
--- a/stix2/patterns.py
+++ b/stix2/patterns.py
@@ -24,7 +24,7 @@ class TimestampConstant(_Constant):
         self.value = value
 
     def __str__(self):
-        return "'%s'" % escape_quotes_and_backslashes(self.value)
+        return "t'%s'" % escape_quotes_and_backslashes(self.value)
 
 
 class IntegerConstant(_Constant):

--- a/stix2/test/test_pattern_expressions.py
+++ b/stix2/test/test_pattern_expressions.py
@@ -170,3 +170,18 @@ def test_set_op():
     exp = stix2.ObservationExpression(stix2.IsSubsetComparisonExpression("network-traffic:dst_ref.value",
                                                                          "2001:0db8:dead:beef:0000:0000:0000:0000/64"))
     assert str(exp) == "[network-traffic:dst_ref.value ISSUBSET '2001:0db8:dead:beef:0000:0000:0000:0000/64']"
+
+
+# [(file:name = 'pdf.exe' OR file:size = '371712') AND file:created = t'2014-01-13T07:03:17Z']
+def test_timestamp():
+    exp_or = stix2.OrBooleanExpression([stix2.EqualityComparisonExpression("file:name",
+                                                                            "pdf.exe"),
+                                        stix2.EqualityComparisonExpression("file:size",
+                                                                            stix2.IntegerConstant('371712'))])
+    exp_paren = stix2.ParentheticalExpression(exp_or)
+    exp_and = stix2.AndBooleanExpression([exp_paren,
+                                          stix2.EqualityComparisonExpression("file:created",
+                                                                             stix2.TimestampConstant('2014-01-13T07:03:17Z'))])
+    exp = stix2.ObservationExpression(exp_and)
+    assert str(exp) == "[(file:name = 'pdf.exe' OR file:size = 371712) AND file:created = t'2014-01-13T07:03:17Z']"
+

--- a/stix2/test/test_pattern_expressions.py
+++ b/stix2/test/test_pattern_expressions.py
@@ -172,16 +172,6 @@ def test_set_op():
     assert str(exp) == "[network-traffic:dst_ref.value ISSUBSET '2001:0db8:dead:beef:0000:0000:0000:0000/64']"
 
 
-# [(file:name = 'pdf.exe' OR file:size = '371712') AND file:created = t'2014-01-13T07:03:17Z']
 def test_timestamp():
-    exp_or = stix2.OrBooleanExpression([stix2.EqualityComparisonExpression("file:name",
-                                                                            "pdf.exe"),
-                                        stix2.EqualityComparisonExpression("file:size",
-                                                                            stix2.IntegerConstant('371712'))])
-    exp_paren = stix2.ParentheticalExpression(exp_or)
-    exp_and = stix2.AndBooleanExpression([exp_paren,
-                                          stix2.EqualityComparisonExpression("file:created",
-                                                                             stix2.TimestampConstant('2014-01-13T07:03:17Z'))])
-    exp = stix2.ObservationExpression(exp_and)
-    assert str(exp) == "[(file:name = 'pdf.exe' OR file:size = 371712) AND file:created = t'2014-01-13T07:03:17Z']"
-
+    ts = stix2.TimestampConstant('2014-01-13T07:03:17Z')
+    assert str(ts) == "t'2014-01-13T07:03:17Z'"


### PR DESCRIPTION
Minor fix...

Noticed that in pattern expressions timestamp constants are prefixed by 't'