### PR TITLE
Update TAXIICollectionSink.add() to use serialize()

### DIFF
--- a/stix2/base.py
+++ b/stix2/base.py
@@ -191,7 +191,7 @@ class _STIXBase(collections.Mapping):
             **kwargs: The arguments for a json.dumps() call.
 
         Returns:
-            dict: The serialized JSON object.
+            str: The serialized JSON object.
 
         Note:
             The argument ``pretty=True`` will output the STIX object following

--- a/stix2/datastore/taxii.py
+++ b/stix2/datastore/taxii.py
@@ -83,8 +83,7 @@ class TAXIICollectionSink(DataSink):
             # adding list of something - recurse on each
             for obj in stix_data:
                 self.add(obj, version=version)
-            else:
-                return  # If the list is empty just return.
+            return
 
         elif isinstance(stix_data, str):
             # adding json encoded string of STIX content

--- a/stix2/datastore/taxii.py
+++ b/stix2/datastore/taxii.py
@@ -83,6 +83,8 @@ class TAXIICollectionSink(DataSink):
             # adding list of something - recurse on each
             for obj in stix_data:
                 self.add(obj, version=version)
+            else:
+                return  # If the list is empty just return.
 
         elif isinstance(stix_data, str):
             # adding json encoded string of STIX content

--- a/stix2/datastore/taxii.py
+++ b/stix2/datastore/taxii.py
@@ -67,14 +67,17 @@ class TAXIICollectionSink(DataSink):
         """
         if isinstance(stix_data, _STIXBase):
             # adding python STIX object
-            bundle = dict(Bundle(stix_data, allow_custom=self.allow_custom))
+            if stix_data["type"] == "bundle":
+                bundle = stix_data.serialize(encoding="utf-8")
+            else:
+                bundle = Bundle(stix_data, allow_custom=self.allow_custom).serialize(encoding="utf-8")
 
         elif isinstance(stix_data, dict):
             # adding python dict (of either Bundle or STIX obj)
             if stix_data["type"] == "bundle":
-                bundle = stix_data
+                bundle = parse(stix_data, allow_custom=self.allow_custom, version=version).serialize(encoding="utf-8")
             else:
-                bundle = dict(Bundle(stix_data, allow_custom=self.allow_custom))
+                bundle = Bundle(stix_data, allow_custom=self.allow_custom).serialize(encoding="utf-8")
 
         elif isinstance(stix_data, list):
             # adding list of something - recurse on each
@@ -85,9 +88,9 @@ class TAXIICollectionSink(DataSink):
             # adding json encoded string of STIX content
             stix_data = parse(stix_data, allow_custom=self.allow_custom, version=version)
             if stix_data["type"] == "bundle":
-                bundle = dict(stix_data)
+                bundle = stix_data.serialize(encoding="utf-8")
             else:
-                bundle = dict(Bundle(stix_data, allow_custom=self.allow_custom))
+                bundle = Bundle(stix_data, allow_custom=self.allow_custom).serialize(encoding="utf-8")
 
         else:
             raise TypeError("stix_data must be as STIX object(or list of),json formatted STIX (or list of), or a json formatted STIX bundle")


### PR DESCRIPTION
Also call `parse()` on `dict` objects. Pass UTF-8 strings to taxii2client.