### PR TITLE
119 taxii filters

### DIFF
--- a/stix2/datastore/filters.py
+++ b/stix2/datastore/filters.py
@@ -35,7 +35,11 @@ def _check_filter_components(prop, op, value):
 
     if type(value) not in FILTER_VALUE_TYPES:
         # check filter value type is supported
-        raise TypeError("Filter value type '%s' is not supported. The type must be a Python immutable type or dictionary" % type(value))
+        raise TypeError("Filter value of '%s' is not supported. The type must be a Python immutable type or dictionary" % type(value))
+
+    if prop == "type" and "_" in value:
+        # check filter where the property is type, value (type name) cannot have underscores
+        raise ValueError("Filter for property 'type' cannot have its value '%s' include underscores" % value)
 
     return True
 

--- a/stix2/test/test_datastore.py
+++ b/stix2/test/test_datastore.py
@@ -220,7 +220,8 @@ def test_filter_value_type_check():
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", complex(2, -1))
-    assert "Filter value of '<type 'complex'>' is not supported" in str(excinfo.value)
+    assert any([s in str(excinfo.value) for s in ["<type 'complex'>", "'<class 'complex'>'"]])
+    assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", set([16, 23]))

--- a/stix2/test/test_datastore.py
+++ b/stix2/test/test_datastore.py
@@ -215,7 +215,8 @@ def test_filter_value_type_check():
     with pytest.raises(TypeError) as excinfo:
         Filter('created', '=', object())
     # On Python 2, the type of object() is `<type 'object'>` On Python 3, it's `<class 'object'>`.
-    assert "Filter value of '<type 'object'>' is not supported" in str(excinfo.value)
+    assert any([s in str(excinfo.value) for s in ["<type 'object'>", "'<class 'object'>'"]])
+    assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", complex(2, -1))

--- a/stix2/test/test_datastore.py
+++ b/stix2/test/test_datastore.py
@@ -225,7 +225,8 @@ def test_filter_value_type_check():
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", set([16, 23]))
-    assert "Filter value of '<type 'set'>' is not supported" in str(excinfo.value)
+    assert any([s in str(excinfo.value) for s in ["<type 'set'>", "'<class 'set'>'"]])
+    assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
 
 def test_filter_type_underscore_check():

--- a/stix2/test/test_datastore.py
+++ b/stix2/test/test_datastore.py
@@ -148,18 +148,18 @@ def test_parse_taxii_filters():
         Filter("created_by_ref", "=", "Bane"),
     ]
 
-    expected_params = {
-        "added_after": "2016-02-01T00:00:01.000Z",
-        "match[id]": "taxii stix object ID",
-        "match[type]": "taxii stix object ID",
-        "match[version]": "first"
-    }
+    taxii_filters_expected = set([
+        Filter("added_after", "=", "2016-02-01T00:00:01.000Z"),
+        Filter("id", "=", "taxii stix object ID"),
+        Filter("type", "=", "taxii stix object ID"),
+        Filter("version", "=", "first")
+    ])
 
     ds = taxii.TAXIICollectionSource(collection)
 
     taxii_filters = ds._parse_taxii_filters(query)
 
-    assert taxii_filters == expected_params
+    assert taxii_filters == taxii_filters_expected
 
 
 def test_add_get_remove_filter():


### PR DESCRIPTION
Covers:

- #119 - Filters that are destined for TAXII server are extracted and sent to taxii2client as keywords. The STIX objects returned from TAXII are then evaluated against the rest of the filters in the query. Filters that are sent to TAXII are not re-evaluated locally against the STIX objects again - doing so causes error as TAXII filter properties are outside the scope of STIX2 common properties and thus would cause STIX objects to be discarded; specifically for filters with properties 'version', 'added_after'. This code was tested against local Medallion server.

- #136 - I put a check for this when Filters are initialized. Its a little incongruous within the context of the other more generic checks. If dont want the check to occur in the Filter initialization, then would have to be when the Filter is applied in _check_filter(). 