### PR TITLE
Improve Tox test harness

### DIFF
--- a/stix2/test/test_external_reference.py
+++ b/stix2/test/test_external_reference.py
@@ -42,7 +42,7 @@ def test_external_reference_capec():
     )
 
     assert str(ref) == CAPEC
-    assert re.match("ExternalReference\(source_name=u?'capec', external_id=u?'CAPEC-550'\)", repr(ref))
+    assert re.match("ExternalReference\\(source_name=u?'capec', external_id=u?'CAPEC-550'\\)", repr(ref))
 
 
 CAPEC_URL = """{
@@ -109,7 +109,7 @@ def test_external_reference_offline():
     )
 
     assert str(ref) == OFFLINE
-    assert re.match("ExternalReference\(source_name=u?'ACME Threat Intel', description=u?'Threat report'\)", repr(ref))
+    assert re.match("ExternalReference\\(source_name=u?'ACME Threat Intel', description=u?'Threat report'\\)", repr(ref))
     # Yikes! This works
     assert eval("stix2." + repr(ref)) == ref
 

--- a/stix2/test/test_malware.py
+++ b/stix2/test/test_malware.py
@@ -126,7 +126,7 @@ def test_parse_malware(data):
 
 
 def test_parse_malware_invalid_labels():
-    data = re.compile('\[.+\]', re.DOTALL).sub('1', EXPECTED_MALWARE)
+    data = re.compile('\\[.+\\]', re.DOTALL).sub('1', EXPECTED_MALWARE)
     with pytest.raises(ValueError) as excinfo:
         stix2.parse(data)
     assert "Invalid value for Malware 'labels'" in str(excinfo.value)

--- a/stix2/test/test_pattern_expressions.py
+++ b/stix2/test/test_pattern_expressions.py
@@ -319,13 +319,13 @@ def test_invalid_binary_constant():
 
 def test_escape_quotes_and_backslashes():
     exp = stix2.MatchesComparisonExpression("file:name",
-                                            "^Final Report.+\.exe$")
+                                            "^Final Report.+\\.exe$")
     assert str(exp) == "file:name MATCHES '^Final Report.+\\\\.exe$'"
 
 
 def test_like():
     exp = stix2.LikeComparisonExpression("directory:path",
-                                         "C:\Windows\%\\foo")
+                                         "C:\\Windows\\%\\foo")
     assert str(exp) == "directory:path LIKE 'C:\\\\Windows\\\\%\\\\foo'"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pycodestyle,isort-check
+envlist = py27,py34,py35,py36,style,isort-check
 
 [testenv]
 deps =
@@ -10,21 +10,16 @@ deps =
     coverage
     taxii2-client
 commands =
-    py.test --ignore=stix2/test/test_workbench.py --cov=stix2 stix2/test/ --cov-report term-missing
-    py.test stix2/test/test_workbench.py --cov=stix2 --cov-report term-missing --cov-append
+    pytest --ignore=stix2/test/test_workbench.py --cov=stix2 stix2/test/ --cov-report term-missing
+    pytest stix2/test/test_workbench.py --cov=stix2 --cov-report term-missing --cov-append
 
 passenv = CI TRAVIS TRAVIS_*
 
-[testenv:pycodestyle]
+[testenv:style]
 deps =
   flake8
-  pycodestyle
 commands =
-  pycodestyle ./stix2
   flake8
-
-[pycodestyle]
-max-line-length=160
 
 [flake8]
 max-line-length=160
@@ -37,7 +32,7 @@ commands =
 
 [travis]
 python =
-  2.7: py27, pycodestyle
-  3.4: py34, pycodestyle
-  3.5: py35, pycodestyle
-  3.6: py36, pycodestyle
+  2.7: py27, style
+  3.4: py34, style
+  3.5: py35, style
+  3.6: py36, style


### PR DESCRIPTION
- No need for both pycodestyle and flake8; flake8 includes the former.
- Use the proper pytest invocation.

This should also fix Travis. It was failing because of https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior, but when I fixed it there was another error because the latest version of flake8 is incompatible with the latest version of pycodestyle. With this PR Tox will use the version of flake8 that didn't check the deprecated backslash-character pair behavior, but the issue is fixed so it won't come up when flake8 upgrades its version of pycodestyle in the future.