### PR TITLE
Fix make_constant when value is already a constant

### DIFF
--- a/stix2/patterns.py
+++ b/stix2/patterns.py
@@ -147,6 +147,9 @@ class ListConstant(_Constant):
 
 
 def make_constant(value):
+    if isinstance(value, _Constant):
+        return value
+
     try:
         return parse_into_datetime(value)
     except ValueError:

--- a/stix2/test/test_pattern_expressions.py
+++ b/stix2/test/test_pattern_expressions.py
@@ -372,3 +372,9 @@ def test_invalid_startstop_qualifier():
         stix2.StartStopQualifier(datetime.date(2016, 6, 1),
                                  'foo')
     assert 'is not a valid argument for a Start/Stop Qualifier' in str(excinfo)
+
+
+def test_make_constant_already_a_constant():
+    str_const = stix2.StringConstant('Foo')
+    result = stix2.patterns.make_constant(str_const)
+    assert result is str_const


### PR DESCRIPTION
This fixes a bug discovered in the elevator.

Fixes #171.