### PR TITLE
Cannot execute sample code.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,7 @@ To parse a STIX JSON string into a Python STIX object, use
             "malicious-activity"
         ],
         "name": "File hash for malware variant",
-        "pattern": "[file:hashes.md5 =
-        'd41d8cd98f00b204e9800998ecf8427e']",
+        "pattern": "[file:hashes.md5 ='d41d8cd98f00b204e9800998ecf8427e']",
         "valid_from": "2017-09-26T23:33:39.829952Z"
     }""")
     print(indicator)


### PR DESCRIPTION
I tried to execute the sample code of parse() on python 2.7 and 3.0.
But It occured JSONDecodeError because the "pattern" value of this sample JSON  are described as multi-line. 
To ensure that the sample code works, this value shuld be single-line.