### PR TITLE
Correct "image_weight" to "image_width".

### DIFF
--- a/stix2/test/test_observed_data.py
+++ b/stix2/test/test_observed_data.py
@@ -765,6 +765,51 @@ def test_file_example_with_RasterImageExt_Object():
     assert f.extensions["raster-image-ext"].exif_tags["XResolution"] == 4928
 
 
+RASTER_IMAGE_EXT = """{
+"type": "observed-data",
+"id": "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf",
+"created": "2016-04-06T19:58:16.000Z",
+"modified": "2016-04-06T19:58:16.000Z",
+"first_observed": "2015-12-21T19:00:00Z",
+"last_observed": "2015-12-21T19:00:00Z",
+"number_observed": 1,
+"objects": {
+  "0": {
+    "type": "file",
+    "name": "picture.jpg",
+    "hashes": {
+      "SHA-256": "35a01331e9ad96f751278b891b6ea09699806faedfa237d40513d92ad1b7100f"
+    },
+    "extensions": {
+      "raster-image-ext": {
+        "image_height": 768,
+        "image_width": 1024,
+        "bits_per_pixel": 72,
+        "image_compression_algorithm": "JPEG",
+        "exif_tags": {
+          "Make": "Nikon",
+          "Model": "D7000",
+          "XResolution": 4928,
+          "YResolution": 3264
+        }
+      }
+    }
+  }
+}
+}
+"""
+
+
+def test_raster_image_ext_parse():
+    obj = stix2.parse(RASTER_IMAGE_EXT, allow_custom=False)
+    assert obj.objects["0"].extensions['raster-image-ext'].image_width == 1024
+
+
+def test_raster_images_ext_create():
+    ext = stix2.RasterImageExt(image_width=1024)
+    assert "image_width" in str(ext)
+
+
 def test_file_example_with_WindowsPEBinaryExt():
     f = stix2.File(name="qwerty.dll",
                    extensions={

--- a/stix2/test/test_observed_data.py
+++ b/stix2/test/test_observed_data.py
@@ -801,7 +801,7 @@ RASTER_IMAGE_EXT = """{
 
 
 def test_raster_image_ext_parse():
-    obj = stix2.parse(RASTER_IMAGE_EXT, allow_custom=False)
+    obj = stix2.parse(RASTER_IMAGE_EXT)
     assert obj.objects["0"].extensions['raster-image-ext'].image_width == 1024
 
 

--- a/stix2/v20/observables.py
+++ b/stix2/v20/observables.py
@@ -302,7 +302,7 @@ class RasterImageExt(_Extension):
     _properties = OrderedDict()
     _properties.update([
         ('image_height', IntegerProperty()),
-        ('image_weight', IntegerProperty()),
+        ('image_width', IntegerProperty()),
         ('bits_per_pixel', IntegerProperty()),
         ('image_compression_algorithm', StringProperty()),
         ('exif_tags', DictionaryProperty()),


### PR DESCRIPTION
Can you review this, @emmanvg and @clenk . Want to get a second set of eyes on this. Without the change to `stix2/v20/observables.py`, the test will fail. Once we merge this in, we'll need to make the same change in `stix2/v21/observables.py` in the `stix2.1` branch.