### PR TITLE
python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - python: 3.7 # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+      dist: xenial
+      sudo: true
 install:
   - pip install -U pip setuptools
   - pip install tox-travis pre-commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install -U pip setuptools
   - pip install tox-travis pre-commit

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords="stix stix2 json cti cyber threat intelligence",
     packages=find_packages(exclude=['*.test']),

--- a/stix2/base.py
+++ b/stix2/base.py
@@ -331,3 +331,8 @@ class _Extension(_STIXBase):
     def _check_object_constraints(self):
         super(_Extension, self)._check_object_constraints()
         self._check_at_least_one_property()
+
+
+def _cls_init(cls, obj, kwargs):
+    if getattr(cls, '__init__', object.__init__) is not object.__init__:
+        cls.__init__(obj, **kwargs)

--- a/stix2/v20/common.py
+++ b/stix2/v20/common.py
@@ -2,7 +2,7 @@
 
 from collections import OrderedDict
 
-from ..base import _STIXBase
+from ..base import _cls_init, _STIXBase
 from ..markings import _MarkingsMixin
 from ..properties import (HashesProperty, IDProperty, ListProperty, Property,
                           ReferenceProperty, SelectorProperty, StringProperty,
@@ -169,14 +169,7 @@ def CustomMarking(type='x-custom-marking', properties=None):
 
             def __init__(self, **kwargs):
                 _STIXBase.__init__(self, **kwargs)
-                try:
-                    cls.__init__(self, **kwargs)
-                except (AttributeError, TypeError) as e:
-                    # Don't accidentally catch errors raised in a custom __init__()
-                    if ("has no attribute '__init__'" in str(e) or
-                            str(e) == "object.__init__() takes no parameters"):
-                        return
-                    raise e
+                _cls_init(cls, self, kwargs)
 
         _register_marking(_Custom)
         return _Custom

--- a/stix2/v20/observables.py
+++ b/stix2/v20/observables.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 import copy
 import re
 
-from ..base import _Extension, _Observable, _STIXBase
+from ..base import _cls_init, _Extension, _Observable, _STIXBase
 from ..exceptions import (AtLeastOnePropertyError, CustomContentError,
                           DependentPropertiesError, ParseError)
 from ..properties import (BinaryProperty, BooleanProperty, DictionaryProperty,
@@ -1027,14 +1027,7 @@ def CustomObservable(type='x-custom-observable', properties=None):
 
             def __init__(self, **kwargs):
                 _Observable.__init__(self, **kwargs)
-                try:
-                    cls.__init__(self, **kwargs)
-                except (AttributeError, TypeError) as e:
-                    # Don't accidentally catch errors raised in a custom __init__()
-                    if ("has no attribute '__init__'" in str(e) or
-                            str(e) == "object.__init__() takes no parameters"):
-                        return
-                    raise e
+                _cls_init(cls, self, kwargs)
 
         _register_observable(_Custom)
         return _Custom
@@ -1090,14 +1083,7 @@ def CustomExtension(observable=None, type='x-custom-observable', properties=None
 
             def __init__(self, **kwargs):
                 _Extension.__init__(self, **kwargs)
-                try:
-                    cls.__init__(self, **kwargs)
-                except (AttributeError, TypeError) as e:
-                    # Don't accidentally catch errors raised in a custom __init__()
-                    if ("has no attribute '__init__'" in str(e) or
-                            str(e) == "object.__init__() takes no parameters"):
-                        return
-                    raise e
+                _cls_init(cls, self, kwargs)
 
         _register_extension(observable, _Custom)
         return _Custom

--- a/stix2/v20/sdo.py
+++ b/stix2/v20/sdo.py
@@ -6,7 +6,7 @@ import re
 
 import stix2
 
-from ..base import _STIXBase
+from ..base import _cls_init, _STIXBase
 from ..markings import _MarkingsMixin
 from ..properties import (BooleanProperty, IDProperty, IntegerProperty,
                           ListProperty, PatternProperty, ReferenceProperty,
@@ -400,14 +400,7 @@ def CustomObject(type='x-custom-type', properties=None):
 
             def __init__(self, **kwargs):
                 _STIXBase.__init__(self, **kwargs)
-                try:
-                    cls.__init__(self, **kwargs)
-                except (AttributeError, TypeError) as e:
-                    # Don't accidentally catch errors raised in a custom __init__()
-                    if ("has no attribute '__init__'" in str(e) or
-                            str(e) == "object.__init__() takes no parameters"):
-                        return
-                    raise e
+                _cls_init(cls, self, kwargs)
 
         stix2._register_type(_Custom, version="2.0")
         return _Custom

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,style,isort-check,packaging
+envlist = py27,py34,py35,py36,py37,style,isort-check,packaging
 
 [testenv]
 deps =
@@ -43,3 +43,4 @@ python =
   3.4: py34, style
   3.5: py35, style
   3.6: py36, style, packaging
+  3.7: py37, style


### PR DESCRIPTION
I have tried to update one of my projects to Python 3.7, but right now this is only dependency left that is not yet supporting it, so here is a patch to fix that:)

In case you are wondering what was broken on Python 3.7:
```
In [1]: object(a=1)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-5acd2be7f9d9> in <module>()
----> 1 object(a=1)

TypeError: object() takes no arguments
```
the message changed from `no parameters` to `no arguments`. Anyway, I don't think it is a good idea to relay on message text anyway so instead I just check does class redefine `__init__` method or not.