### PR TITLE
Fix `created` millisecond precision in TLPs

### DIFF
--- a/stix2/test/test_markings.py
+++ b/stix2/test/test_markings.py
@@ -11,7 +11,7 @@ from .constants import MARKING_DEFINITION_ID
 EXPECTED_TLP_MARKING_DEFINITION = """{
     "type": "marking-definition",
     "id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
-    "created": "2017-01-20T00:00:00Z",
+    "created": "2017-01-20T00:00:00.000Z",
     "definition_type": "tlp",
     "definition": {
         "tlp": "white"

--- a/stix2/v20/common.py
+++ b/stix2/v20/common.py
@@ -1,6 +1,7 @@
 """STIX 2 Common Data Types and Properties."""
 
 from collections import OrderedDict
+import copy
 
 from ..base import _cls_init, _STIXBase
 from ..markings import _MarkingsMixin
@@ -123,6 +124,13 @@ class MarkingDefinition(_STIXBase, _MarkingsMixin):
                 marking_type = OBJ_MAP_MARKING[kwargs['definition_type']]
             except KeyError:
                 raise ValueError("definition_type must be a valid marking type")
+
+            if marking_type == TLPMarking:
+                # TLP instances in the spec have millisecond precision unlike other markings
+                self._properties = copy.deepcopy(self._properties)
+                self._properties.update([
+                    ('created', TimestampProperty(default=lambda: NOW, precision='millisecond')),
+                ])
 
             if not isinstance(kwargs['definition'], marking_type):
                 defn = _get_dict(kwargs['definition'])


### PR DESCRIPTION
A marking definition's `created` property doesn't require millisecond preprecision, but for TLP markings the TLP instances provided in the spec must be used and they all use millisecond precision.

Fixes #215.