### PR TITLE
Fix error when printing WindowsRegistryKey

### DIFF
--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -11,7 +11,7 @@ import uuid
 from six import string_types, text_type
 from stix2patterns.validator import run_validator
 
-from .base import _STIXBase
+from .base import _Observable, _STIXBase
 from .core import STIX2_OBJ_MAPS, parse, parse_observable
 from .exceptions import CustomContentError, DictionaryKeyError
 from .utils import _get_dict, get_class_hierarchy_names, parse_into_datetime
@@ -165,6 +165,19 @@ class ListProperty(Property):
             raise ValueError("must not be empty.")
 
         return result
+
+
+class CallableValues(list):
+    """Wrapper to allow `values()` method on WindowsRegistryKey objects.
+    Needed because `values` is also a property.
+    """
+
+    def __init__(self, parent_instance, *args, **kwargs):
+        self.parent_instance = parent_instance
+        super(CallableValues, self).__init__(*args, **kwargs)
+
+    def __call__(self):
+        return _Observable.values(self.parent_instance)
 
 
 class StringProperty(Property):

--- a/stix2/test/v20/test_observed_data.py
+++ b/stix2/test/v20/test_observed_data.py
@@ -1290,6 +1290,8 @@ def test_windows_registry_key_example():
     assert w.values[0].name == "Foo"
     assert w.values[0].data == "qwerty"
     assert w.values[0].data_type == "REG_SZ"
+    # ensure no errors in serialization because of 'values'
+    assert "Foo" in str(w)
 
 
 def test_x509_certificate_example():

--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -1264,6 +1264,8 @@ def test_windows_registry_key_example():
     assert w.values[0].name == "Foo"
     assert w.values[0].data == "qwerty"
     assert w.values[0].data_type == "REG_SZ"
+    # ensure no errors in serialization because of 'values'
+    assert "Foo" in str(w)
 
 
 def test_x509_certificate_example():

--- a/stix2/v20/observables.py
+++ b/stix2/v20/observables.py
@@ -12,7 +12,7 @@ from ..base import _Extension, _Observable, _STIXBase
 from ..custom import _custom_extension_builder, _custom_observable_builder
 from ..exceptions import AtLeastOnePropertyError, DependentPropertiesError
 from ..properties import (
-    BinaryProperty, BooleanProperty, DictionaryProperty,
+    BinaryProperty, BooleanProperty, CallableValues, DictionaryProperty,
     EmbeddedObjectProperty, EnumProperty, ExtensionsProperty, FloatProperty,
     HashesProperty, HexProperty, IntegerProperty, ListProperty,
     ObjectReferenceProperty, StringProperty, TimestampProperty, TypeProperty,
@@ -704,19 +704,6 @@ class WindowsRegistryValueType(_STIXBase):
             ]),
         ),
     ])
-
-
-class CallableValues(list):
-    """Wrapper to allow `values()` method on WindowsRegistryKey objects.
-    Needed because `values` is also a property.
-    """
-
-    def __init__(self, parent_instance, *args, **kwargs):
-        self.parent_instance = parent_instance
-        super(CallableValues, self).__init__(*args, **kwargs)
-
-    def __call__(self):
-        return _Observable.values(self.parent_instance)
 
 
 class WindowsRegistryKey(_Observable):

--- a/stix2/v20/observables.py
+++ b/stix2/v20/observables.py
@@ -706,6 +706,19 @@ class WindowsRegistryValueType(_STIXBase):
     ])
 
 
+class CallableValues(list):
+    """Wrapper to allow `values()` method on WindowsRegistryKey objects.
+    Needed because `values` is also a property.
+    """
+
+    def __init__(self, parent_instance, *args, **kwargs):
+        self.parent_instance = parent_instance
+        super(CallableValues, self).__init__(*args, **kwargs)
+
+    def __call__(self):
+        return _Observable.values(self.parent_instance)
+
+
 class WindowsRegistryKey(_Observable):
     """For more detailed information on this object's properties, see
     `the STIX 2.0 specification <http://docs.oasis-open.org/cti/stix/v2.0/cs01/part4-cyber-observable-objects/stix-v2.0-cs01-part4-cyber-observable-objects.html#_Toc496716291>`__.
@@ -726,7 +739,7 @@ class WindowsRegistryKey(_Observable):
     @property
     def values(self):
         # Needed because 'values' is a property on collections.Mapping objects
-        return self._inner['values']
+        return CallableValues(self, self._inner['values'])
 
 
 class X509V3ExtenstionsType(_STIXBase):

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -12,7 +12,7 @@ from ..base import _Extension, _Observable, _STIXBase
 from ..custom import _custom_extension_builder, _custom_observable_builder
 from ..exceptions import AtLeastOnePropertyError, DependentPropertiesError
 from ..properties import (
-    BinaryProperty, BooleanProperty, DictionaryProperty,
+    BinaryProperty, BooleanProperty, CallableValues, DictionaryProperty,
     EmbeddedObjectProperty, EnumProperty, ExtensionsProperty, FloatProperty,
     HashesProperty, HexProperty, IntegerProperty, ListProperty,
     ObjectReferenceProperty, StringProperty, TimestampProperty, TypeProperty,
@@ -756,19 +756,6 @@ class WindowsRegistryValueType(_STIXBase):
             ]),
         ),
     ])
-
-
-class CallableValues(list):
-    """Wrapper to allow `values()` method on WindowsRegistryKey objects.
-    Needed because `values` is also a property.
-    """
-
-    def __init__(self, parent_instance, *args, **kwargs):
-        self.parent_instance = parent_instance
-        super(CallableValues, self).__init__(*args, **kwargs)
-
-    def __call__(self):
-        return _Observable.values(self.parent_instance)
 
 
 class WindowsRegistryKey(_Observable):

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -758,6 +758,19 @@ class WindowsRegistryValueType(_STIXBase):
     ])
 
 
+class CallableValues(list):
+    """Wrapper to allow `values()` method on WindowsRegistryKey objects.
+    Needed because `values` is also a property.
+    """
+
+    def __init__(self, parent_instance, *args, **kwargs):
+        self.parent_instance = parent_instance
+        super(CallableValues, self).__init__(*args, **kwargs)
+
+    def __call__(self):
+        return _Observable.values(self.parent_instance)
+
+
 class WindowsRegistryKey(_Observable):
     # TODO: Add link
     """For more detailed information on this object's properties, see
@@ -779,7 +792,7 @@ class WindowsRegistryKey(_Observable):
     @property
     def values(self):
         # Needed because 'values' is a property on collections.Mapping objects
-        return self._inner['values']
+        return CallableValues(self, self._inner['values'])
 
 
 class X509V3ExtenstionsType(_STIXBase):


### PR DESCRIPTION
Caused by WindowsRegistryKey having a 'values' property. Fixes #236.