### PR TITLE
Remove dictionary/extension property non-empty req

### DIFF
--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -291,8 +291,6 @@ class DictionaryProperty(Property):
             dictified = _get_dict(value)
         except ValueError:
             raise ValueError("The dictionary property must contain a dictionary")
-        if dictified == {}:
-            raise ValueError("The dictionary property must contain a non-empty dictionary")
         for k in dictified.keys():
             if self.spec_version == '2.0':
                 if len(k) < 3:
@@ -498,8 +496,6 @@ class ExtensionsProperty(DictionaryProperty):
             dictified = copy.deepcopy(dictified)
         except ValueError:
             raise ValueError("The extensions property must contain a dictionary")
-        if dictified == {}:
-            raise ValueError("The extensions property must contain a non-empty dictionary")
 
         v = 'v' + self.spec_version.replace('.', '')
 

--- a/stix2/test/v20/test_observed_data.py
+++ b/stix2/test/v20/test_observed_data.py
@@ -1140,6 +1140,16 @@ def test_process_example_windows_process_ext_empty():
     assert excinfo.value.properties == sorted(properties_of_extension)
 
 
+def test_process_example_extensions_empty():
+    proc = stix2.v20.Process(
+        pid=314,
+        name="foobar.exe",
+        extensions={},
+    )
+
+    assert '{}' in str(proc)
+
+
 def test_process_example_with_WindowsProcessExt_Object():
     p = stix2.v20.Process(extensions={
         "windows-process-ext": stix2.v20.WindowsProcessExt(

--- a/stix2/test/v20/test_observed_data.py
+++ b/stix2/test/v20/test_observed_data.py
@@ -1140,15 +1140,6 @@ def test_process_example_windows_process_ext_empty():
     assert excinfo.value.properties == sorted(properties_of_extension)
 
 
-def test_process_example_extensions_empty():
-    with pytest.raises(stix2.exceptions.InvalidValueError) as excinfo:
-            stix2.v20.Process(extensions={})
-
-    assert excinfo.value.cls == stix2.v20.Process
-    assert excinfo.value.prop_name == 'extensions'
-    assert 'non-empty dictionary' in excinfo.value.reason
-
-
 def test_process_example_with_WindowsProcessExt_Object():
     p = stix2.v20.Process(extensions={
         "windows-process-ext": stix2.v20.WindowsProcessExt(

--- a/stix2/test/v20/test_properties.py
+++ b/stix2/test/v20/test_properties.py
@@ -360,7 +360,6 @@ def test_dictionary_property_invalid_key(d):
 
 @pytest.mark.parametrize(
     "d", [
-        ({}, "The dictionary property must contain a non-empty dictionary"),
         # TODO: This error message could be made more helpful. The error is caused
         # because `json.loads()` doesn't like the *single* quotes around the key
         # name, even though they are valid in a Python dictionary. While technically

--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -1114,6 +1114,16 @@ def test_process_example_windows_process_ext_empty():
     assert excinfo.value.properties == sorted(properties_of_extension)
 
 
+def test_process_example_extensions_empty():
+    proc = stix2.v20.Process(
+        pid=314,
+        name="foobar.exe",
+        extensions={},
+    )
+
+    assert '{}' in str(proc)
+
+
 def test_process_example_with_WindowsProcessExt_Object():
     p = stix2.v21.Process(extensions={
         "windows-process-ext": stix2.v21.WindowsProcessExt(

--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -1117,7 +1117,6 @@ def test_process_example_windows_process_ext_empty():
 def test_process_example_extensions_empty():
     proc = stix2.v21.Process(
         pid=314,
-        name="foobar.exe",
         extensions={},
     )
 

--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -1115,7 +1115,7 @@ def test_process_example_windows_process_ext_empty():
 
 
 def test_process_example_extensions_empty():
-    proc = stix2.v20.Process(
+    proc = stix2.v21.Process(
         pid=314,
         name="foobar.exe",
         extensions={},

--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -1114,15 +1114,6 @@ def test_process_example_windows_process_ext_empty():
     assert excinfo.value.properties == sorted(properties_of_extension)
 
 
-def test_process_example_extensions_empty():
-    with pytest.raises(stix2.exceptions.InvalidValueError) as excinfo:
-            stix2.v21.Process(extensions={})
-
-    assert excinfo.value.cls == stix2.v21.Process
-    assert excinfo.value.prop_name == 'extensions'
-    assert 'non-empty dictionary' in excinfo.value.reason
-
-
 def test_process_example_with_WindowsProcessExt_Object():
     p = stix2.v21.Process(extensions={
         "windows-process-ext": stix2.v21.WindowsProcessExt(

--- a/stix2/test/v21/test_properties.py
+++ b/stix2/test/v21/test_properties.py
@@ -369,7 +369,6 @@ def test_dictionary_property_invalid_key(d):
 
 @pytest.mark.parametrize(
     "d", [
-        ({}, "The dictionary property must contain a non-empty dictionary"),
         # TODO: This error message could be made more helpful. The error is caused
         # because `json.loads()` doesn't like the *single* quotes around the key
         # name, even though they are valid in a Python dictionary. While technically


### PR DESCRIPTION
Only bundle.objects and observed-data.objects have a requirement to include at least one item.

Fixes #238.