### PR TITLE
Avoid issues using parse on bundles

### DIFF
--- a/stix2/v20/bundle.py
+++ b/stix2/v20/bundle.py
@@ -38,7 +38,7 @@ class Bundle(_STIXBase):
 
     def get_obj(self, obj_uuid):
         if "objects" in self._inner:
-            found_objs = [elem for elem in self.objects if elem.id == obj_uuid]
+            found_objs = [elem for elem in self.objects if elem['id'] == obj_uuid]
             if found_objs == []:
                 raise KeyError("'%s' does not match the id property of any of the bundle's objects" % obj_uuid)
             return found_objs

--- a/stix2/v21/bundle.py
+++ b/stix2/v21/bundle.py
@@ -36,7 +36,7 @@ class Bundle(_STIXBase):
 
     def get_obj(self, obj_uuid):
         if "objects" in self._inner:
-            found_objs = [elem for elem in self.objects if elem.id == obj_uuid]
+            found_objs = [elem for elem in self.objects if elem['id'] == obj_uuid]
             if found_objs == []:
                 raise KeyError("'%s' does not match the id property of any of the bundle's objects" % obj_uuid)
             return found_objs


### PR DESCRIPTION
As the type of a custom object is dict, there is an issue with the 'parse' function when it is called on a bundle containing custom objects.

Any comment if you see another way to handle this issue is welcome