### PR TITLE
Added Missing Location Name Field to v21 sdo

### DIFF
--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -237,6 +237,7 @@ class Location(STIXDomainObject):
         ('created_by_ref', ReferenceProperty(type='identity')),
         ('created', TimestampProperty(default=lambda: NOW, precision='millisecond')),
         ('modified', TimestampProperty(default=lambda: NOW, precision='millisecond')),
+        ('name', StringProperty()),
         ('description', StringProperty()),
         ('latitude', FloatProperty(min=-90.0, max=90.0)),
         ('longitude', FloatProperty(min=-180.0, max=180.0)),


### PR DESCRIPTION
Location was missing the optional name field, causing:

`stix2.exceptions.ExtraPropertiesError: Unexpected properties for Location: (name).`

When running

` return Location(
            name="united kingdom",
            country="UK"
        )`

Reference to the working draft where name is specified:

https://docs.google.com/document/d/1bkMmU1PxlwlAwjrMmyWV147rvLcRs2x62FicHbpH2gU/edit#