### PR TITLE
Added IDProperty() to observables in v21

### DIFF
--- a/stix2/base.py
+++ b/stix2/base.py
@@ -143,7 +143,6 @@ class _STIXBase(collections.Mapping):
         if custom_props and not isinstance(custom_props, dict):
             raise ValueError("'custom_properties' must be a dictionary")
         if not self.__allow_custom:
-            print(set(kwargs), set(self._properties))
             extra_kwargs = list(set(kwargs) - set(self._properties))
             if extra_kwargs:
                 raise ExtraPropertiesError(cls, extra_kwargs)

--- a/stix2/base.py
+++ b/stix2/base.py
@@ -73,7 +73,8 @@ class _STIXBase(collections.Mapping):
         custom_props.sort()
 
         all_properties = list(self._properties.keys())
-        all_properties.extend(custom_props)  # Any custom properties to the bottom
+        # Any custom properties to the bottom
+        all_properties.extend(custom_props)
 
         return all_properties
 
@@ -91,7 +92,8 @@ class _STIXBase(collections.Mapping):
             except ValueError as exc:
                 if self.__allow_custom and isinstance(exc, CustomContentError):
                     return
-                raise InvalidValueError(self.__class__, prop_name, reason=str(exc))
+                raise InvalidValueError(
+                    self.__class__, prop_name, reason=str(exc))
 
     # interproperty constraint methods
 
@@ -100,15 +102,18 @@ class _STIXBase(collections.Mapping):
         count = len(set(list_of_properties).intersection(current_properties))
         # at_least_one allows for xor to be checked
         if count > 1 or (at_least_one and count == 0):
-            raise MutuallyExclusivePropertiesError(self.__class__, list_of_properties)
+            raise MutuallyExclusivePropertiesError(
+                self.__class__, list_of_properties)
 
     def _check_at_least_one_property(self, list_of_properties=None):
         if not list_of_properties:
-            list_of_properties = sorted(list(self.__class__._properties.keys()))
+            list_of_properties = sorted(
+                list(self.__class__._properties.keys()))
             if 'type' in list_of_properties:
                 list_of_properties.remove('type')
         current_properties = self.properties_populated()
-        list_of_properties_populated = set(list_of_properties).intersection(current_properties)
+        list_of_properties_populated = set(
+            list_of_properties).intersection(current_properties)
         if list_of_properties and (not list_of_properties_populated or list_of_properties_populated == set(['extensions'])):
             raise AtLeastOnePropertyError(self.__class__, list_of_properties)
 
@@ -119,7 +124,8 @@ class _STIXBase(collections.Mapping):
                 if not self.get(p) and self.get(dp):
                     failed_dependency_pairs.append((p, dp))
         if failed_dependency_pairs:
-            raise DependentPropertiesError(self.__class__, failed_dependency_pairs)
+            raise DependentPropertiesError(
+                self.__class__, failed_dependency_pairs)
 
     def _check_object_constraints(self):
         for m in self.get('granular_markings', []):
@@ -137,6 +143,7 @@ class _STIXBase(collections.Mapping):
         if custom_props and not isinstance(custom_props, dict):
             raise ValueError("'custom_properties' must be a dictionary")
         if not self.__allow_custom:
+            print(set(kwargs), set(self._properties))
             extra_kwargs = list(set(kwargs) - set(self._properties))
             if extra_kwargs:
                 raise ExtraPropertiesError(cls, extra_kwargs)
@@ -276,7 +283,8 @@ class _STIXBase(collections.Mapping):
             def sort_by(element):
                 return find_property_index(self, *element)
 
-            kwargs.update({'indent': 4, 'separators': (',', ': '), 'item_sort_key': sort_by})
+            kwargs.update({'indent': 4, 'separators': (
+                ',', ': '), 'item_sort_key': sort_by})
 
         if include_optional_defaults:
             return json.dumps(self, cls=STIXJSONIncludeOptionalDefaultsEncoder, **kwargs)
@@ -291,7 +299,8 @@ class _Observable(_STIXBase):
         self._STIXBase__valid_refs = kwargs.pop('_valid_refs', [])
 
         self.__allow_custom = kwargs.get('allow_custom', False)
-        self._properties['extensions'].allow_custom = kwargs.get('allow_custom', False)
+        self._properties['extensions'].allow_custom = kwargs.get(
+            'allow_custom', False)
 
         super(_Observable, self).__init__(**kwargs)
 
@@ -300,7 +309,8 @@ class _Observable(_STIXBase):
             return  # don't check if refs are valid
 
         if ref not in self._STIXBase__valid_refs:
-            raise InvalidObjRefError(self.__class__, prop_name, "'%s' is not a valid object in local scope" % ref)
+            raise InvalidObjRefError(
+                self.__class__, prop_name, "'%s' is not a valid object in local scope" % ref)
 
         try:
             allowed_types = prop.contained.valid_types
@@ -313,11 +323,13 @@ class _Observable(_STIXBase):
             except AttributeError:
                 ref_type = self._STIXBase__valid_refs[ref]
         except TypeError:
-            raise ValueError("'%s' must be created with _valid_refs as a dict, not a list." % self.__class__.__name__)
+            raise ValueError(
+                "'%s' must be created with _valid_refs as a dict, not a list." % self.__class__.__name__)
 
         if allowed_types:
             if ref_type not in allowed_types:
-                raise InvalidObjRefError(self.__class__, prop_name, "object reference '%s' is of an invalid type '%s'" % (ref, ref_type))
+                raise InvalidObjRefError(
+                    self.__class__, prop_name, "object reference '%s' is of an invalid type '%s'" % (ref, ref_type))
 
     def _check_property(self, prop_name, prop, kwargs):
         super(_Observable, self)._check_property(prop_name, prop, kwargs)

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -14,7 +14,7 @@ from ..exceptions import AtLeastOnePropertyError, DependentPropertiesError
 from ..properties import (
     BinaryProperty, BooleanProperty, CallableValues, DictionaryProperty,
     EmbeddedObjectProperty, EnumProperty, ExtensionsProperty, FloatProperty,
-    HashesProperty, HexProperty, IntegerProperty, ListProperty,
+    HashesProperty, HexProperty, IDProperty, IntegerProperty, ListProperty,
     ObjectReferenceProperty, StringProperty, TimestampProperty, TypeProperty,
 )
 
@@ -28,6 +28,7 @@ class Artifact(_Observable):
     _type = 'artifact'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('mime_type', StringProperty()),
         ('payload_bin', BinaryProperty()),
         ('url', StringProperty()),
@@ -52,6 +53,7 @@ class AutonomousSystem(_Observable):
     _type = 'autonomous-system'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('number', IntegerProperty(required=True)),
         ('name', StringProperty()),
         ('rir', StringProperty()),
@@ -68,13 +70,15 @@ class Directory(_Observable):
     _type = 'directory'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('path', StringProperty(required=True)),
         ('path_enc', StringProperty()),
         # these are not the created/modified timestamps of the object itself
         ('created', TimestampProperty()),
         ('modified', TimestampProperty()),
         ('accessed', TimestampProperty()),
-        ('contains_refs', ListProperty(ObjectReferenceProperty(valid_types=['file', 'directory']))),
+        ('contains_refs', ListProperty(
+            ObjectReferenceProperty(valid_types=['file', 'directory']))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -88,8 +92,10 @@ class DomainName(_Observable):
     _type = 'domain-name'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
-        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(valid_types=['ipv4-addr', 'ipv6-addr', 'domain-name']))),
+        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(
+            valid_types=['ipv4-addr', 'ipv6-addr', 'domain-name']))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -103,6 +109,7 @@ class EmailAddress(_Observable):
     _type = 'email-addr'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
         ('display_name', StringProperty()),
         ('belongs_to_ref', ObjectReferenceProperty(valid_types='user-account')),
@@ -118,7 +125,8 @@ class EmailMIMEComponent(_STIXBase):
 
     _properties = OrderedDict([
         ('body', StringProperty()),
-        ('body_raw_ref', ObjectReferenceProperty(valid_types=['artifact', 'file'])),
+        ('body_raw_ref', ObjectReferenceProperty(
+            valid_types=['artifact', 'file'])),
         ('content_type', StringProperty()),
         ('content_disposition', StringProperty()),
     ])
@@ -137,6 +145,7 @@ class EmailMessage(_Observable):
     _type = 'email-message'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('is_multipart', BooleanProperty(required=True)),
         ('date', TimestampProperty()),
         ('content_type', StringProperty()),
@@ -149,7 +158,8 @@ class EmailMessage(_Observable):
         ('received_lines', ListProperty(StringProperty)),
         ('additional_header_fields', DictionaryProperty(spec_version='2.1')),
         ('body', StringProperty()),
-        ('body_multipart', ListProperty(EmbeddedObjectProperty(type=EmailMIMEComponent))),
+        ('body_multipart', ListProperty(
+            EmbeddedObjectProperty(type=EmailMIMEComponent))),
         ('raw_email_ref', ObjectReferenceProperty(valid_types='artifact')),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
@@ -159,7 +169,8 @@ class EmailMessage(_Observable):
         self._check_properties_dependency(['is_multipart'], ['body_multipart'])
         if self.get('is_multipart') is True and self.get('body'):
             # 'body' MAY only be used if is_multipart is false.
-            raise DependentPropertiesError(self.__class__, [('is_multipart', 'body')])
+            raise DependentPropertiesError(
+                self.__class__, [('is_multipart', 'body')])
 
 
 class ArchiveExt(_Extension):
@@ -170,7 +181,8 @@ class ArchiveExt(_Extension):
 
     _type = 'archive-ext'
     _properties = OrderedDict([
-        ('contains_refs', ListProperty(ObjectReferenceProperty(valid_types='file'), required=True)),
+        ('contains_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='file'), required=True)),
         ('comment', StringProperty()),
     ])
 
@@ -197,7 +209,8 @@ class NTFSExt(_Extension):
     _type = 'ntfs-ext'
     _properties = OrderedDict([
         ('sid', StringProperty()),
-        ('alternate_data_streams', ListProperty(EmbeddedObjectProperty(type=AlternateDataStream))),
+        ('alternate_data_streams', ListProperty(
+            EmbeddedObjectProperty(type=AlternateDataStream))),
     ])
 
 
@@ -309,7 +322,8 @@ class WindowsPEBinaryExt(_Extension):
         ('size_of_optional_header', IntegerProperty(min=0)),
         ('characteristics_hex', HexProperty()),
         ('file_header_hashes', HashesProperty(spec_version='2.1')),
-        ('optional_header', EmbeddedObjectProperty(type=WindowsPEOptionalHeaderType)),
+        ('optional_header', EmbeddedObjectProperty(
+            type=WindowsPEOptionalHeaderType)),
         ('sections', ListProperty(EmbeddedObjectProperty(type=WindowsPESection))),
     ])
 
@@ -323,6 +337,7 @@ class File(_Observable):
     _type = 'file'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('hashes', HashesProperty(spec_version='2.1')),
         ('size', IntegerProperty(min=0)),
         ('name', StringProperty()),
@@ -353,9 +368,12 @@ class IPv4Address(_Observable):
     _type = 'ipv4-addr'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
-        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(valid_types='mac-addr'))),
-        ('belongs_to_refs', ListProperty(ObjectReferenceProperty(valid_types='autonomous-system'))),
+        ('resolves_to_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='mac-addr'))),
+        ('belongs_to_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='autonomous-system'))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -369,9 +387,12 @@ class IPv6Address(_Observable):
     _type = 'ipv6-addr'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
-        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(valid_types='mac-addr'))),
-        ('belongs_to_refs', ListProperty(ObjectReferenceProperty(valid_types='autonomous-system'))),
+        ('resolves_to_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='mac-addr'))),
+        ('belongs_to_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='autonomous-system'))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -385,6 +406,7 @@ class MACAddress(_Observable):
     _type = 'mac-addr'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
@@ -399,6 +421,7 @@ class Mutex(_Observable):
     _type = 'mutex'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('name', StringProperty(required=True)),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
@@ -505,11 +528,14 @@ class NetworkTraffic(_Observable):
     _type = 'network-traffic'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('start', TimestampProperty()),
         ('end', TimestampProperty()),
         ('is_active', BooleanProperty()),
-        ('src_ref', ObjectReferenceProperty(valid_types=['ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
-        ('dst_ref', ObjectReferenceProperty(valid_types=['ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
+        ('src_ref', ObjectReferenceProperty(valid_types=[
+         'ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
+        ('dst_ref', ObjectReferenceProperty(valid_types=[
+         'ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
         ('src_port', IntegerProperty(min=0, max=65535)),
         ('dst_port', IntegerProperty(min=0, max=65535)),
         ('protocols', ListProperty(StringProperty, required=True)),
@@ -520,8 +546,10 @@ class NetworkTraffic(_Observable):
         ('ipfix', DictionaryProperty(spec_version='2.1')),
         ('src_payload_ref', ObjectReferenceProperty(valid_types='artifact')),
         ('dst_payload_ref', ObjectReferenceProperty(valid_types='artifact')),
-        ('encapsulates_refs', ListProperty(ObjectReferenceProperty(valid_types='network-traffic'))),
-        ('encapsulates_by_ref', ObjectReferenceProperty(valid_types='network-traffic')),
+        ('encapsulates_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='network-traffic'))),
+        ('encapsulates_by_ref', ObjectReferenceProperty(
+            valid_types='network-traffic')),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -592,7 +620,8 @@ class WindowsServiceExt(_Extension):
                 "SERVICE_SYSTEM_ALERT",
             ]),
         ),
-        ('service_dll_refs', ListProperty(ObjectReferenceProperty(valid_types='file'))),
+        ('service_dll_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='file'))),
         (
             'service_type', EnumProperty(allowed=[
                 "SERVICE_KERNEL_DRIVER",
@@ -624,6 +653,7 @@ class Process(_Observable):
     _type = 'process'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('is_hidden', BooleanProperty()),
         ('pid', IntegerProperty()),
         # this is not the created timestamps of the object itself
@@ -631,7 +661,8 @@ class Process(_Observable):
         ('cwd', StringProperty()),
         ('command_line', StringProperty()),
         ('environment_variables', DictionaryProperty(spec_version='2.1')),
-        ('opened_connection_refs', ListProperty(ObjectReferenceProperty(valid_types='network-traffic'))),
+        ('opened_connection_refs', ListProperty(
+            ObjectReferenceProperty(valid_types='network-traffic'))),
         ('creator_user_ref', ObjectReferenceProperty(valid_types='user-account')),
         ('image_ref', ObjectReferenceProperty(valid_types='file')),
         ('parent_ref', ObjectReferenceProperty(valid_types='process')),
@@ -663,6 +694,7 @@ class Software(_Observable):
     _type = 'software'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('name', StringProperty(required=True)),
         ('cpe', StringProperty()),
         ('languages', ListProperty(StringProperty)),
@@ -681,6 +713,7 @@ class URL(_Observable):
     _type = 'url'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
@@ -710,6 +743,7 @@ class UserAccount(_Observable):
     _type = 'user-account'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('user_id', StringProperty()),
         ('credential', StringProperty()),
         ('account_login', StringProperty()),
@@ -767,6 +801,7 @@ class WindowsRegistryKey(_Observable):
     _type = 'windows-registry-key'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('key', StringProperty()),
         ('values', ListProperty(EmbeddedObjectProperty(type=WindowsRegistryValueType))),
         # this is not the modified timestamps of the object itself
@@ -818,6 +853,7 @@ class X509Certificate(_Observable):
     _type = 'x509-certificate'
     _properties = OrderedDict([
         ('type', TypeProperty(_type)),
+        ('id', IDProperty(_type)),
         ('is_self_signed', BooleanProperty()),
         ('hashes', HashesProperty(spec_version='2.1')),
         ('version', StringProperty()),

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -165,8 +165,7 @@ class EmailMessage(_Observable):
         self._check_properties_dependency(['is_multipart'], ['body_multipart'])
         if self.get('is_multipart') is True and self.get('body'):
             # 'body' MAY only be used if is_multipart is false.
-            raise DependentPropertiesError(
-                self.__class__, [('is_multipart', 'body')])
+            raise DependentPropertiesError(self.__class__, [('is_multipart', 'body')])
 
 
 class ArchiveExt(_Extension):

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -77,8 +77,7 @@ class Directory(_Observable):
         ('created', TimestampProperty()),
         ('modified', TimestampProperty()),
         ('accessed', TimestampProperty()),
-        ('contains_refs', ListProperty(
-            ObjectReferenceProperty(valid_types=['file', 'directory']))),
+        ('contains_refs', ListProperty(ObjectReferenceProperty(valid_types=['file', 'directory']))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -94,8 +93,7 @@ class DomainName(_Observable):
         ('type', TypeProperty(_type)),
         ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
-        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(
-            valid_types=['ipv4-addr', 'ipv6-addr', 'domain-name']))),
+        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(valid_types=['ipv4-addr', 'ipv6-addr', 'domain-name']))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -125,8 +123,7 @@ class EmailMIMEComponent(_STIXBase):
 
     _properties = OrderedDict([
         ('body', StringProperty()),
-        ('body_raw_ref', ObjectReferenceProperty(
-            valid_types=['artifact', 'file'])),
+        ('body_raw_ref', ObjectReferenceProperty(valid_types=['artifact', 'file'])),
         ('content_type', StringProperty()),
         ('content_disposition', StringProperty()),
     ])
@@ -158,8 +155,7 @@ class EmailMessage(_Observable):
         ('received_lines', ListProperty(StringProperty)),
         ('additional_header_fields', DictionaryProperty(spec_version='2.1')),
         ('body', StringProperty()),
-        ('body_multipart', ListProperty(
-            EmbeddedObjectProperty(type=EmailMIMEComponent))),
+        ('body_multipart', ListProperty(EmbeddedObjectProperty(type=EmailMIMEComponent))),
         ('raw_email_ref', ObjectReferenceProperty(valid_types='artifact')),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
@@ -181,8 +177,7 @@ class ArchiveExt(_Extension):
 
     _type = 'archive-ext'
     _properties = OrderedDict([
-        ('contains_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='file'), required=True)),
+        ('contains_refs', ListProperty(ObjectReferenceProperty(valid_types='file'), required=True)),
         ('comment', StringProperty()),
     ])
 
@@ -209,8 +204,7 @@ class NTFSExt(_Extension):
     _type = 'ntfs-ext'
     _properties = OrderedDict([
         ('sid', StringProperty()),
-        ('alternate_data_streams', ListProperty(
-            EmbeddedObjectProperty(type=AlternateDataStream))),
+        ('alternate_data_streams', ListProperty(EmbeddedObjectProperty(type=AlternateDataStream))),
     ])
 
 
@@ -322,8 +316,7 @@ class WindowsPEBinaryExt(_Extension):
         ('size_of_optional_header', IntegerProperty(min=0)),
         ('characteristics_hex', HexProperty()),
         ('file_header_hashes', HashesProperty(spec_version='2.1')),
-        ('optional_header', EmbeddedObjectProperty(
-            type=WindowsPEOptionalHeaderType)),
+        ('optional_header', EmbeddedObjectProperty(type=WindowsPEOptionalHeaderType)),
         ('sections', ListProperty(EmbeddedObjectProperty(type=WindowsPESection))),
     ])
 
@@ -370,10 +363,8 @@ class IPv4Address(_Observable):
         ('type', TypeProperty(_type)),
         ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
-        ('resolves_to_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='mac-addr'))),
-        ('belongs_to_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='autonomous-system'))),
+        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(valid_types='mac-addr'))),
+        ('belongs_to_refs', ListProperty(ObjectReferenceProperty(valid_types='autonomous-system'))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -389,10 +380,8 @@ class IPv6Address(_Observable):
         ('type', TypeProperty(_type)),
         ('id', IDProperty(_type)),
         ('value', StringProperty(required=True)),
-        ('resolves_to_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='mac-addr'))),
-        ('belongs_to_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='autonomous-system'))),
+        ('resolves_to_refs', ListProperty(ObjectReferenceProperty(valid_types='mac-addr'))),
+        ('belongs_to_refs', ListProperty(ObjectReferenceProperty(valid_types='autonomous-system'))),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -532,10 +521,8 @@ class NetworkTraffic(_Observable):
         ('start', TimestampProperty()),
         ('end', TimestampProperty()),
         ('is_active', BooleanProperty()),
-        ('src_ref', ObjectReferenceProperty(valid_types=[
-         'ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
-        ('dst_ref', ObjectReferenceProperty(valid_types=[
-         'ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
+        ('src_ref', ObjectReferenceProperty(valid_types=['ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
+        ('dst_ref', ObjectReferenceProperty(valid_types=['ipv4-addr', 'ipv6-addr', 'mac-addr', 'domain-name'])),
         ('src_port', IntegerProperty(min=0, max=65535)),
         ('dst_port', IntegerProperty(min=0, max=65535)),
         ('protocols', ListProperty(StringProperty, required=True)),
@@ -546,10 +533,8 @@ class NetworkTraffic(_Observable):
         ('ipfix', DictionaryProperty(spec_version='2.1')),
         ('src_payload_ref', ObjectReferenceProperty(valid_types='artifact')),
         ('dst_payload_ref', ObjectReferenceProperty(valid_types='artifact')),
-        ('encapsulates_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='network-traffic'))),
-        ('encapsulates_by_ref', ObjectReferenceProperty(
-            valid_types='network-traffic')),
+        ('encapsulates_refs', ListProperty(ObjectReferenceProperty(valid_types='network-traffic'))),
+        ('encapsulates_by_ref', ObjectReferenceProperty(valid_types='network-traffic')),
         ('extensions', ExtensionsProperty(spec_version='2.1', enclosing_type=_type)),
     ])
 
@@ -620,8 +605,7 @@ class WindowsServiceExt(_Extension):
                 "SERVICE_SYSTEM_ALERT",
             ]),
         ),
-        ('service_dll_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='file'))),
+        ('service_dll_refs', ListProperty(ObjectReferenceProperty(valid_types='file'))),
         (
             'service_type', EnumProperty(allowed=[
                 "SERVICE_KERNEL_DRIVER",
@@ -661,8 +645,7 @@ class Process(_Observable):
         ('cwd', StringProperty()),
         ('command_line', StringProperty()),
         ('environment_variables', DictionaryProperty(spec_version='2.1')),
-        ('opened_connection_refs', ListProperty(
-            ObjectReferenceProperty(valid_types='network-traffic'))),
+        ('opened_connection_refs', ListProperty(ObjectReferenceProperty(valid_types='network-traffic'))),
         ('creator_user_ref', ObjectReferenceProperty(valid_types='user-account')),
         ('image_ref', ObjectReferenceProperty(valid_types='file')),
         ('parent_ref', ObjectReferenceProperty(valid_types='process')),

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -38,7 +38,8 @@ class AttackPattern(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -68,7 +69,8 @@ class Campaign(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -104,7 +106,8 @@ class CourseOfAction(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -134,7 +137,8 @@ class Identity(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -165,7 +169,8 @@ class Indicator(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -208,7 +213,8 @@ class IntrusionSet(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -237,6 +243,7 @@ class Location(STIXDomainObject):
         ('created_by_ref', ReferenceProperty(type='identity')),
         ('created', TimestampProperty(default=lambda: NOW, precision='millisecond')),
         ('modified', TimestampProperty(default=lambda: NOW, precision='millisecond')),
+        ('name', StringProperty()),
         ('description', StringProperty()),
         ('latitude', FloatProperty(min=-90.0, max=90.0)),
         ('longitude', FloatProperty(min=-180.0, max=180.0)),
@@ -252,7 +259,8 @@ class Location(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -260,7 +268,8 @@ class Location(STIXDomainObject):
         super(self.__class__, self)._check_object_constraints()
 
         if self.get('precision') is not None:
-            self._check_properties_dependency(['longitude', 'latitude'], ['precision'])
+            self._check_properties_dependency(
+                ['longitude', 'latitude'], ['precision'])
 
         self._check_properties_dependency(['latitude'], ['longitude'])
         self._check_properties_dependency(['longitude'], ['latitude'])
@@ -284,8 +293,10 @@ class Location(STIXDomainObject):
         if latitude is not None and longitude is not None:
             params.extend([str(latitude), str(longitude)])
         else:
-            properties = ['street_address', 'city', 'country', 'region', 'administrative_area', 'postal_code']
-            params = [self.get(prop) for prop in properties if self.get(prop) is not None]
+            properties = ['street_address', 'city', 'country',
+                          'region', 'administrative_area', 'postal_code']
+            params = [self.get(prop)
+                      for prop in properties if self.get(prop) is not None]
 
         return self._to_maps_url_dispatcher(map_engine, params)
 
@@ -295,7 +306,8 @@ class Location(STIXDomainObject):
         elif map_engine == "Bing Maps":
             return self._to_bing_maps_url(params)
         else:
-            raise ValueError(map_engine + " is not a valid or currently-supported map engine")
+            raise ValueError(
+                map_engine + " is not a valid or currently-supported map engine")
 
     def _to_google_maps_url(self, params):
         url_base = "https://www.google.com/maps/search/?api=1&query="
@@ -312,7 +324,8 @@ class Location(STIXDomainObject):
         for i in range(1, len(params)):
             url_ending = url_ending + "," + params[i]
 
-        final_url = url_base + quote_plus(url_ending) + "&lvl=16"   # level 16 zoom so long/lat searches shown more clearly
+        # level 16 zoom so long/lat searches shown more clearly
+        final_url = url_base + quote_plus(url_ending) + "&lvl=16"
         return final_url
 
 
@@ -339,7 +352,8 @@ class Malware(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -367,7 +381,8 @@ class Note(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -395,13 +410,15 @@ class ObservedData(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
     def __init__(self, *args, **kwargs):
         self.__allow_custom = kwargs.get('allow_custom', False)
-        self._properties['objects'].allow_custom = kwargs.get('allow_custom', False)
+        self._properties['objects'].allow_custom = kwargs.get(
+            'allow_custom', False)
 
         super(ObservedData, self).__init__(*args, **kwargs)
 
@@ -409,8 +426,10 @@ class ObservedData(STIXDomainObject):
         super(self.__class__, self)._check_object_constraints()
 
         if self.get('number_observed', 1) == 1:
-            self._check_properties_dependency(['first_observed'], ['last_observed'])
-            self._check_properties_dependency(['last_observed'], ['first_observed'])
+            self._check_properties_dependency(
+                ['first_observed'], ['last_observed'])
+            self._check_properties_dependency(
+                ['last_observed'], ['first_observed'])
 
         first_observed = self.get('first_observed')
         last_observed = self.get('last_observed')
@@ -453,7 +472,8 @@ class Opinion(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -482,7 +502,8 @@ class Report(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -517,7 +538,8 @@ class ThreatActor(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -546,7 +568,8 @@ class Tool(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -572,7 +595,8 @@ class Vulnerability(STIXDomainObject):
         ('confidence', IntegerProperty()),
         ('lang', StringProperty()),
         ('external_references', ListProperty(ExternalReference)),
-        ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+        ('object_marking_refs', ListProperty(
+            ReferenceProperty(type='marking-definition'))),
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
@@ -613,8 +637,10 @@ def CustomObject(type='x-custom-type', properties=None):
                 ('spec_version', StringProperty(fixed='2.1')),
                 ('id', IDProperty(type)),
                 ('created_by_ref', ReferenceProperty(type='identity')),
-                ('created', TimestampProperty(default=lambda: NOW, precision='millisecond')),
-                ('modified', TimestampProperty(default=lambda: NOW, precision='millisecond')),
+                ('created', TimestampProperty(
+                    default=lambda: NOW, precision='millisecond')),
+                ('modified', TimestampProperty(
+                    default=lambda: NOW, precision='millisecond')),
             ],
             [x for x in properties if not x[0].startswith('x_')],
             [
@@ -623,10 +649,12 @@ def CustomObject(type='x-custom-type', properties=None):
                 ('confidence', IntegerProperty()),
                 ('lang', StringProperty()),
                 ('external_references', ListProperty(ExternalReference)),
-                ('object_marking_refs', ListProperty(ReferenceProperty(type='marking-definition'))),
+                ('object_marking_refs', ListProperty(
+                    ReferenceProperty(type='marking-definition'))),
                 ('granular_markings', ListProperty(GranularMarking)),
             ],
-            sorted([x for x in properties if x[0].startswith('x_')], key=lambda x: x[0]),
+            sorted([x for x in properties if x[0].startswith('x_')],
+                   key=lambda x: x[0]),
         ]))
         return _custom_object_builder(cls, type, _properties, '2.1')
 

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -415,14 +415,14 @@ class ObservedData(STIXDomainObject):
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
-    # Removing this as it should not be needed any longer (with object_refs)
-    # def __init__(self, *args, **kwargs):
-    #     self.__allow_custom = kwargs.get('allow_custom', False)
+    # Removing this as it should not be needed any longer (with object)
+    def __init__(self, *args, **kwargs):
+        self.__allow_custom = kwargs.get('allow_custom', False)
     #     Removing the objects check as it is replaced with object_refs in 21
     #     self._properties['objects'].allow_custom = kwargs.get(
     #         'allow_custom', False)
 
-    #     super(ObservedData, self).__init__(*args, **kwargs)
+        super(ObservedData, self).__init__(*args, **kwargs)
 
     def _check_object_constraints(self):
         super(self.__class__, self)._check_object_constraints()

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -422,7 +422,7 @@ class ObservedData(STIXDomainObject):
         # self._properties['objects'].allow_custom = kwargs.get(
         #     'allow_custom', False)
 
-        super(ObservedData, self).__init__(*args, **kwargs)
+        # super(ObservedData, self).__init__(*args, **kwargs)
 
     def _check_object_constraints(self):
         super(self.__class__, self)._check_object_constraints()

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -415,15 +415,14 @@ class ObservedData(STIXDomainObject):
         ('granular_markings', ListProperty(GranularMarking)),
     ])
 
-    def __init__(self, *args, **kwargs):
-        print('running here...')
-        pass
-        self.__allow_custom = kwargs.get('allow_custom', False)
-        Removing the objects check as it is replaced with object_refs in 21
-        self._properties['objects'].allow_custom = kwargs.get(
-            'allow_custom', False)
+    # Removing this as it should not be needed any longer (with object_refs)
+    # def __init__(self, *args, **kwargs):
+    #     self.__allow_custom = kwargs.get('allow_custom', False)
+    #     Removing the objects check as it is replaced with object_refs in 21
+    #     self._properties['objects'].allow_custom = kwargs.get(
+    #         'allow_custom', False)
 
-        super(ObservedData, self).__init__(*args, **kwargs)
+    #     super(ObservedData, self).__init__(*args, **kwargs)
 
     def _check_object_constraints(self):
         super(self.__class__, self)._check_object_constraints()

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -416,7 +416,8 @@ class ObservedData(STIXDomainObject):
     ])
 
     def __init__(self, *args, **kwargs):
-        self.__allow_custom = kwargs.get('allow_custom', False)
+        pass
+        # self.__allow_custom = kwargs.get('allow_custom', False)
         # Removing the objects check as it is replaced with object_refs in 21
         # self._properties['objects'].allow_custom = kwargs.get(
         #     'allow_custom', False)

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -416,13 +416,14 @@ class ObservedData(STIXDomainObject):
     ])
 
     def __init__(self, *args, **kwargs):
+        print('running here...')
         pass
-        # self.__allow_custom = kwargs.get('allow_custom', False)
-        # Removing the objects check as it is replaced with object_refs in 21
-        # self._properties['objects'].allow_custom = kwargs.get(
-        #     'allow_custom', False)
+        self.__allow_custom = kwargs.get('allow_custom', False)
+        Removing the objects check as it is replaced with object_refs in 21
+        self._properties['objects'].allow_custom = kwargs.get(
+            'allow_custom', False)
 
-        # super(ObservedData, self).__init__(*args, **kwargs)
+        super(ObservedData, self).__init__(*args, **kwargs)
 
     def _check_object_constraints(self):
         super(self.__class__, self)._check_object_constraints()

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -404,7 +404,7 @@ class ObservedData(STIXDomainObject):
         ('first_observed', TimestampProperty(required=True)),
         ('last_observed', TimestampProperty(required=True)),
         ('number_observed', IntegerProperty(min=1, max=999999999, required=True)),
-        ('objects', ObservableProperty(spec_version='2.1', required=True)),
+        ('object_refs', ListProperty(ReferenceProperty, required=True)),
         ('revoked', BooleanProperty(default=lambda: False)),
         ('labels', ListProperty(StringProperty)),
         ('confidence', IntegerProperty()),
@@ -417,8 +417,9 @@ class ObservedData(STIXDomainObject):
 
     def __init__(self, *args, **kwargs):
         self.__allow_custom = kwargs.get('allow_custom', False)
-        self._properties['objects'].allow_custom = kwargs.get(
-            'allow_custom', False)
+        # Removing the objects check as it is replaced with object_refs in 21
+        # self._properties['objects'].allow_custom = kwargs.get(
+        #     'allow_custom', False)
 
         super(ObservedData, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Hi all,

I noticed that the v21 implementation was missing IDProperty() on observables which seems to be required for SCOs as part of the wording for the (soon to be open to public review) WSD05:

https://docs.google.com/document/d/1ShNq4c3e1CkfANmD9O--mdZ5H0O_GLnjN28a_yrEaco/edit#heading=h.xzbicbtscatx

Chris