### PR TITLE
Fix deterministic ID handling with unicode

### DIFF
--- a/stix2/base.py
+++ b/stix2/base.py
@@ -394,11 +394,14 @@ class _Observable(_STIXBase):
             if streamlined_obj_vals:
                 data = canonicalize(streamlined_obj_vals, utf8=False)
 
-                # try/except here to enable python 2 compatibility
-                try:
+                # The situation is complicated w.r.t. python 2/3 behavior, so
+                # I'd rather not rely on particular exceptions being raised to
+                # determine what to do.  Better to just check the python version
+                # directly.
+                if six.PY3:
                     return required_prefix + six.text_type(uuid.uuid5(SCO_DET_ID_NAMESPACE, data))
-                except UnicodeDecodeError:
-                    return required_prefix + six.text_type(uuid.uuid5(SCO_DET_ID_NAMESPACE, six.binary_type(data)))
+                else:
+                    return required_prefix + six.text_type(uuid.uuid5(SCO_DET_ID_NAMESPACE, data.encode("utf-8")))
 
         # We return None if there are no values specified for any of the id-contributing-properties
         return None

--- a/stix2/test/v21/test_base.py
+++ b/stix2/test/v21/test_base.py
@@ -1,9 +1,11 @@
 import datetime as dt
 import json
+import uuid
 
 import pytest
 import pytz
 
+import stix2
 from stix2.base import STIXJSONEncoder
 
 
@@ -23,3 +25,14 @@ def test_encode_json_object():
         json.dumps(test_dict, cls=STIXJSONEncoder)
 
     assert " is not JSON serializable" in str(excinfo.value)
+
+
+def test_deterministic_id_unicode():
+    mutex = {'name': u'D*Fl#Ed*\u00a3\u00a8', 'type': 'mutex'}
+    obs = stix2.parse_observable(mutex, version="2.1")
+
+    dd_idx = obs.id.index("--")
+    id_uuid = uuid.UUID(obs.id[dd_idx+2:])
+
+    assert id_uuid.variant == uuid.RFC_4122
+    assert id_uuid.version == 5


### PR DESCRIPTION
Fix deterministic ID handling when there are high-codepoint unicode characters.  Make compatible with both python 2 and 3.

Fixes #292 