### PR TITLE
add encoding option to areas where open() is used

### DIFF
--- a/stix2/datastore/memory.py
+++ b/stix2/datastore/memory.py
@@ -359,8 +359,8 @@ class MemorySource(DataSource):
 
         return all_data
 
-    def load_from_file(self, file_path, version=None):
-        with io.open(os.path.abspath(file_path), "r") as f:
+    def load_from_file(self, file_path, version=None, encoding='utf-8'):
+        with io.open(os.path.abspath(file_path), "r", encoding=encoding) as f:
             stix_data = json.load(f)
 
         _add(self, stix_data, self.allow_custom, version)


### PR DESCRIPTION
Added encoding option to FileSystemSource and MemorySource in areas where open() is used. Default is 'utf-8'

closes #321 