### PR TITLE
327 marking definition changes

### DIFF
--- a/stix2/markings/utils.py
+++ b/stix2/markings/utils.py
@@ -271,8 +271,8 @@ def check_tlp_marking(marking_obj, spec_version):
             else:
                 w = (
                     '{"created": "2017-01-20T00:00:00.000Z", "definition": {"tlp": "white"}, "definition_type": "tlp",'
-                    ' "id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9", "type": "marking-definition",'
-                    ' "spec_version": "2.1"}'
+                    ' "id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9", "name": "TLP:WHITE",'
+                    ' "type": "marking-definition", "spec_version": "2.1"}'
                 )
             if marking_obj["id"] != "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9":
                 raise exceptions.TLPMarkingDefinitionError(marking_obj["id"], w)
@@ -288,8 +288,8 @@ def check_tlp_marking(marking_obj, spec_version):
             else:
                 g = (
                     '{"created": "2017-01-20T00:00:00.000Z", "definition": {"tlp": "green"}, "definition_type": "tlp",'
-                    ' "id": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da", "type": "marking-definition",'
-                    ' "spec_version": "2.1"}'
+                    ' "id": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da", "name": "TLP:GREEN",'
+                    ' "type": "marking-definition", "spec_version": "2.1"}'
                 )
             if marking_obj["id"] != "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da":
                 raise exceptions.TLPMarkingDefinitionError(marking_obj["id"], g)
@@ -305,8 +305,8 @@ def check_tlp_marking(marking_obj, spec_version):
             else:
                 a = (
                     '{"created": "2017-01-20T00:00:00.000Z", "definition": {"tlp": "amber"}, "definition_type": "tlp",'
-                    ' "id": "marking-definition--f88d31f6-486f-44da-b317-01333bde0b82", "type": "marking-definition",'
-                    ' "spec_version": "2.1"}'
+                    ' "id": "marking-definition--f88d31f6-486f-44da-b317-01333bde0b82", "name": "TLP:AMBER",'
+                    ' "type": "marking-definition", "spec_version": "2.1"}'
                 )
             if marking_obj["id"] != "marking-definition--f88d31f6-486f-44da-b317-01333bde0b82":
                 raise exceptions.TLPMarkingDefinitionError(marking_obj["id"], a)
@@ -322,8 +322,8 @@ def check_tlp_marking(marking_obj, spec_version):
             else:
                 r = (
                     '{"created": "2017-01-20T00:00:00.000Z", "definition": {"tlp": "red"}, "definition_type": "tlp",'
-                    ' "id": "marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed", "type": "marking-definition",'
-                    ' "spec_version": "2.1"}'
+                    ' "id": "marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed", "name": "TLP:RED",'
+                    ' "type": "marking-definition", "spec_version": "2.1"}'
                 )
             if marking_obj["id"] != "marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed":
                 raise exceptions.TLPMarkingDefinitionError(marking_obj["id"], r)

--- a/stix2/test/v21/test_marking_definition.py
+++ b/stix2/test/v21/test_marking_definition.py
@@ -12,6 +12,7 @@ def test_bad_id_marking_tlp_white():
         MarkingDefinition(
             id='marking-definition--4c9faac1-3558-43d2-919e-95c88d3bc332',
             definition_type='tlp',
+            name='TLP:WHITE',
             definition=TLPMarking(tlp='white'),
         )
 
@@ -21,6 +22,7 @@ def test_bad_id_marking_tlp_green():
         MarkingDefinition(
             id='marking-definition--93023361-d3cf-4666-bca2-8c017948dc3d',
             definition_type='tlp',
+            name='TLP:GREEN',
             definition=TLPMarking(tlp='green'),
         )
 
@@ -30,6 +32,7 @@ def test_bad_id_marking_tlp_amber():
         MarkingDefinition(
             id='marking-definition--05e32101-a940-42ba-8fe9-39283b999ce4',
             definition_type='tlp',
+            name='TLP:AMBER',
             definition=TLPMarking(tlp='amber'),
         )
 
@@ -39,6 +42,7 @@ def test_bad_id_marking_tlp_red():
         MarkingDefinition(
             id='marking-definition--9eceb00c-c158-43f4-87f8-1e3648de17e2',
             definition_type='tlp',
+            name='TLP:RED',
             definition=TLPMarking(tlp='red'),
         )
 
@@ -48,6 +52,7 @@ def test_bad_created_marking_tlp_white():
         MarkingDefinition(
             id='marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
             definition_type='tlp',
+            name='TLP:WHITE',
             definition=TLPMarking(tlp='white'),
         )
 
@@ -57,6 +62,7 @@ def test_bad_created_marking_tlp_green():
         MarkingDefinition(
             id='marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da',
             definition_type='tlp',
+            name='TLP:GREEN',
             definition=TLPMarking(tlp='green'),
         )
 
@@ -66,6 +72,7 @@ def test_bad_created_marking_tlp_amber():
         MarkingDefinition(
             id='marking-definition--f88d31f6-486f-44da-b317-01333bde0b82',
             definition_type='tlp',
+            name='TLP:AMBER',
             definition=TLPMarking(tlp='amber'),
         )
 
@@ -75,6 +82,7 @@ def test_bad_created_marking_tlp_red():
         MarkingDefinition(
             id='marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed',
             definition_type='tlp',
+            name='TLP:RED',
             definition=TLPMarking(tlp='red'),
         )
 
@@ -86,6 +94,7 @@ def test_successful_tlp_white():
         id='marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
         created='2017-01-20T00:00:00.000Z',
         definition_type='tlp',
+        name='TLP:WHITE',
         definition=TLPMarking(tlp='white'),
     )
 
@@ -97,6 +106,7 @@ def test_successful_tlp_green():
         id='marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da',
         created='2017-01-20T00:00:00.000Z',
         definition_type='tlp',
+        name='TLP:GREEN',
         definition=TLPMarking(tlp='green'),
     )
 
@@ -108,6 +118,7 @@ def test_successful_tlp_amber():
         id='marking-definition--f88d31f6-486f-44da-b317-01333bde0b82',
         created='2017-01-20T00:00:00.000Z',
         definition_type='tlp',
+        name='TLP:AMBER',
         definition=TLPMarking(tlp='amber'),
     )
 
@@ -119,6 +130,7 @@ def test_successful_tlp_red():
         id='marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed',
         created='2017-01-20T00:00:00.000Z',
         definition_type='tlp',
+        name='TLP:RED',
         definition=TLPMarking(tlp='red'),
     )
 

--- a/stix2/test/v21/test_markings.py
+++ b/stix2/test/v21/test_markings.py
@@ -16,6 +16,7 @@ EXPECTED_TLP_MARKING_DEFINITION = """{
     "id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
     "created": "2017-01-20T00:00:00.000Z",
     "definition_type": "tlp",
+    "name": "TLP:WHITE",
     "definition": {
         "tlp": "white"
     }

--- a/stix2/v21/common.py
+++ b/stix2/v21/common.py
@@ -150,6 +150,7 @@ class MarkingDefinition(_STIXBase, _MarkingsMixin):
         ('object_marking_refs', ListProperty(ReferenceProperty(valid_types='marking-definition', spec_version='2.1'))),
         ('granular_markings', ListProperty(GranularMarking)),
         ('definition_type', StringProperty(required=True)),
+        ('name', StringProperty()),
         ('definition', MarkingProperty(required=True)),
     ])
 
@@ -207,6 +208,7 @@ TLP_WHITE = MarkingDefinition(
     id='marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
     created='2017-01-20T00:00:00.000Z',
     definition_type='tlp',
+    name='TLP:WHITE',
     definition=TLPMarking(tlp='white'),
 )
 
@@ -214,6 +216,7 @@ TLP_GREEN = MarkingDefinition(
     id='marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da',
     created='2017-01-20T00:00:00.000Z',
     definition_type='tlp',
+    name='TLP:GREEN',
     definition=TLPMarking(tlp='green'),
 )
 
@@ -221,6 +224,7 @@ TLP_AMBER = MarkingDefinition(
     id='marking-definition--f88d31f6-486f-44da-b317-01333bde0b82',
     created='2017-01-20T00:00:00.000Z',
     definition_type='tlp',
+    name='TLP:AMBER',
     definition=TLPMarking(tlp='amber'),
 )
 
@@ -228,5 +232,6 @@ TLP_RED = MarkingDefinition(
     id='marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed',
     created='2017-01-20T00:00:00.000Z',
     definition_type='tlp',
+    name='TLP:RED',
     definition=TLPMarking(tlp='red'),
 )


### PR DESCRIPTION
Adds the `name` property to v21 MarkingDefinition objects. Update TLP_* constants accordingly.

closes #327