### PR TITLE
Ensure new_version() actually creates a new version with a correct "modified" property value.

### DIFF
--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -285,7 +285,7 @@ def new_version(data, **kwargs):
     cls = type(data)
     if 'modified' not in kwargs:
         old_modified = parse_into_datetime(
-            data["modified"], precision="millisecond"
+            data["modified"], precision="millisecond",
         )
         new_modified = get_timestamp()
         # Ensure the new is newer than the old!

--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -284,11 +284,14 @@ def new_version(data, **kwargs):
 
     cls = type(data)
     if 'modified' not in kwargs:
-        old_modified = parse_into_datetime(data["modified"])
+        old_modified = parse_into_datetime(
+            data["modified"], precision="millisecond"
+        )
         new_modified = get_timestamp()
         # Ensure the new is newer than the old!
-        if new_modified <= old_modified:
-            new_modified = old_modified + dt.timedelta(microseconds=1000)
+        one_ms = dt.timedelta(milliseconds=1)
+        if new_modified - old_modified < one_ms:
+            new_modified = old_modified + one_ms
         kwargs['modified'] = new_modified
     elif 'modified' in data:
         old_modified_property = parse_into_datetime(data.get('modified'), precision='millisecond')

--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -284,7 +284,12 @@ def new_version(data, **kwargs):
 
     cls = type(data)
     if 'modified' not in kwargs:
-        kwargs['modified'] = get_timestamp()
+        old_modified = parse_into_datetime(data["modified"])
+        new_modified = get_timestamp()
+        # Ensure the new is newer than the old!
+        if new_modified <= old_modified:
+            new_modified = old_modified + dt.timedelta(microseconds=1000)
+        kwargs['modified'] = new_modified
     elif 'modified' in data:
         old_modified_property = parse_into_datetime(data.get('modified'), precision='millisecond')
         new_modified_property = parse_into_datetime(kwargs['modified'], precision='millisecond')


### PR DESCRIPTION
Fixes #329 .

Now, if the current timestamp is not later than the old modified property value, the new modified value is set to the old value plus one millisecond.