### PR TITLE
Remove workaround for "values" being both a Mapping method name and STIX property name

### DIFF
--- a/docs/guide/creating.ipynb
+++ b/docs/guide/creating.ipynb
@@ -334,6 +334,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "-----\n",
+    "### Warning\n",
+    "Note that because these objects are designed to be usable as `Mapping`s, the attributes of that interface retain their mapping meanings and can't be used to access STIX object properties.  This includes the attributes:\n",
+    "- keys\n",
+    "- values\n",
+    "- items\n",
+    "- get\n",
+    "-----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Attempting to modify any attributes will raise an error:"
    ]
   },
@@ -1110,21 +1124,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/docs/guide/creating.ipynb
+++ b/docs/guide/creating.ipynb
@@ -334,14 +334,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "-----\n",
-    "### Warning\n",
-    "Note that because these objects are designed to be usable as `Mapping`s, the attributes of that interface retain their mapping meanings and can't be used to access STIX object properties.  This includes the attributes:\n",
-    "- keys\n",
-    "- values\n",
-    "- items\n",
-    "- get\n",
-    "-----"
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "**Warning**\n",
+    "\n",
+    "Note that there are several attributes on these objects used for method names.  Accessing those will return a bound method, not the attribute value.\n",
+    "\n",
+    "</div>\n"
    ]
   },
   {

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -11,7 +11,7 @@ from six import string_types, text_type
 
 import stix2
 
-from .base import _Observable, _STIXBase
+from .base import _STIXBase
 from .core import STIX2_OBJ_MAPS, parse, parse_observable
 from .exceptions import (
     CustomContentError, DictionaryKeyError, MissingPropertiesError,
@@ -217,19 +217,6 @@ class ListProperty(Property):
             raise ValueError("must not be empty.")
 
         return result
-
-
-class CallableValues(list):
-    """Wrapper to allow `values()` method on WindowsRegistryKey objects.
-    Needed because `values` is also a property.
-    """
-
-    def __init__(self, parent_instance, *args, **kwargs):
-        self.parent_instance = parent_instance
-        super(CallableValues, self).__init__(*args, **kwargs)
-
-    def __call__(self):
-        return _Observable.values(self.parent_instance)
 
 
 class StringProperty(Property):

--- a/stix2/test/v20/test_observed_data.py
+++ b/stix2/test/v20/test_observed_data.py
@@ -1301,9 +1301,9 @@ def test_windows_registry_key_example():
         values=[v],
     )
     assert w.key == "hkey_local_machine\\system\\bar\\foo"
-    assert w.values[0].name == "Foo"
-    assert w.values[0].data == "qwerty"
-    assert w.values[0].data_type == "REG_SZ"
+    assert w["values"][0].name == "Foo"
+    assert w["values"][0].data == "qwerty"
+    assert w["values"][0].data_type == "REG_SZ"
     # ensure no errors in serialization because of 'values'
     assert "Foo" in str(w)
 

--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -1382,9 +1382,9 @@ def test_windows_registry_key_example():
         values=[v],
     )
     assert w.key == "hkey_local_machine\\system\\bar\\foo"
-    assert w.values[0].name == "Foo"
-    assert w.values[0].data == "qwerty"
-    assert w.values[0].data_type == "REG_SZ"
+    assert w["values"][0].name == "Foo"
+    assert w["values"][0].data == "qwerty"
+    assert w["values"][0].data_type == "REG_SZ"
     # ensure no errors in serialization because of 'values'
     assert "Foo" in str(w)
 

--- a/stix2/v20/observables.py
+++ b/stix2/v20/observables.py
@@ -12,7 +12,7 @@ from ..base import _Extension, _Observable, _STIXBase
 from ..custom import _custom_extension_builder, _custom_observable_builder
 from ..exceptions import AtLeastOnePropertyError, DependentPropertiesError
 from ..properties import (
-    BinaryProperty, BooleanProperty, CallableValues, DictionaryProperty,
+    BinaryProperty, BooleanProperty, DictionaryProperty,
     EmbeddedObjectProperty, EnumProperty, ExtensionsProperty, FloatProperty,
     HashesProperty, HexProperty, IntegerProperty, ListProperty,
     ObjectReferenceProperty, StringProperty, TimestampProperty, TypeProperty,
@@ -722,11 +722,6 @@ class WindowsRegistryKey(_Observable):
         ('number_of_subkeys', IntegerProperty()),
         ('extensions', ExtensionsProperty(spec_version="2.0", enclosing_type=_type)),
     ])
-
-    @property
-    def values(self):
-        # Needed because 'values' is a property on collections.Mapping objects
-        return CallableValues(self, self._inner['values'])
 
 
 class X509V3ExtenstionsType(_STIXBase):

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -15,7 +15,7 @@ from ..exceptions import (
     AtLeastOnePropertyError, DependentPropertiesError, STIXDeprecationWarning,
 )
 from ..properties import (
-    BinaryProperty, BooleanProperty, CallableValues, DictionaryProperty,
+    BinaryProperty, BooleanProperty, DictionaryProperty,
     EmbeddedObjectProperty, EnumProperty, ExtensionsProperty, FloatProperty,
     HashesProperty, HexProperty, IDProperty, IntegerProperty, ListProperty,
     ObjectReferenceProperty, ReferenceProperty, StringProperty,
@@ -934,11 +934,6 @@ class WindowsRegistryKey(_Observable):
         ('defanged', BooleanProperty(default=lambda: False)),
     ])
     _id_contributing_properties = ["key", "values"]
-
-    @property
-    def values(self):
-        # Needed because 'values' is a property on collections.Mapping objects
-        return CallableValues(self, self._inner['values'])
 
 
 class X509V3ExtenstionsType(_STIXBase):


### PR DESCRIPTION
Fixes #324 .

The workaround didn't work (caused crashes under some circumstances).  Now, attributes whose names conflict with Mapping methods will have the Mapping interpretation.  Same-named STIX object properties will not be accessible as attributes.