### PR TITLE
Fix the filesystem store to support the new top-level 2.1 SCOs.

### DIFF
--- a/stix2/test/v21/stix2_data/directory/directory--572827aa-e0cd-44fd-afd5-a717a7585f39.json
+++ b/stix2/test/v21/stix2_data/directory/directory--572827aa-e0cd-44fd-afd5-a717a7585f39.json
@@ -1,0 +1,11 @@
+{
+    "ctime": "2020-10-06T01:54:32.000Z",
+    "contains_refs": [
+        "directory--80539e31-85f3-4304-bd14-e2e8c10859a5",
+        "file--e9e03175-0357-41b5-a2aa-eb99b455cd0c",
+        "directory--f6c54233-027b-4464-8126-da1324d8f66c"
+    ],
+    "path": "/performance/Democrat.gif",
+    "type": "directory",
+    "id": "directory--572827aa-e0cd-44fd-afd5-a717a7585f39"
+}

--- a/stix2/test/v21/test_datastore_filesystem.py
+++ b/stix2/test/v21/test_datastore_filesystem.py
@@ -221,6 +221,16 @@ def test_filesystem_source_backward_compatible(fs_source):
     assert result.malware_types == ["version four"]
 
 
+def test_filesystem_source_sco(fs_source):
+    results = fs_source.query([stix2.Filter("type", "=", "directory")])
+
+    assert len(results) == 1
+    result = results[0]
+    assert result["type"] == "directory"
+    assert result["id"] == "directory--572827aa-e0cd-44fd-afd5-a717a7585f39"
+    assert result["path"] == "/performance/Democrat.gif"
+
+
 def test_filesystem_sink_add_python_stix_object(fs_sink, fs_source):
     # add python stix object
     camp1 = stix2.v21.Campaign(
@@ -435,6 +445,24 @@ def test_filesystem_sink_marking(fs_sink):
     os.remove(marking_filepath)
 
 
+def test_filesystem_sink_sco(fs_sink):
+    file_sco = {
+        "type": "file",
+        "id": "file--decfcc48-31b3-45f5-87c8-1b3a5d71a307",
+        "name": "cats.png",
+    }
+
+    fs_sink.add(file_sco)
+    sco_filepath = os.path.join(
+        FS_PATH, "file", file_sco["id"] + ".json",
+    )
+
+    assert os.path.exists(sco_filepath)
+
+    os.remove(sco_filepath)
+    os.rmdir(os.path.dirname(sco_filepath))
+
+
 def test_filesystem_store_get_stored_as_bundle(fs_store):
     coa = fs_store.get("course-of-action--95ddb356-7ba0-4bd9-a889-247262b8946f")
     assert coa.id == "course-of-action--95ddb356-7ba0-4bd9-a889-247262b8946f"
@@ -473,9 +501,10 @@ def test_filesystem_store_query_single_filter(fs_store):
 
 def test_filesystem_store_empty_query(fs_store):
     results = fs_store.query()  # returns all
-    assert len(results) == 30
+    assert len(results) == 31
     assert "tool--242f3da3-4425-4d11-8f5c-b842886da966" in [obj.id for obj in results]
     assert "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168" in [obj.id for obj in results]
+    assert "directory--572827aa-e0cd-44fd-afd5-a717a7585f39" in [obj.id for obj in results]
 
 
 def test_filesystem_store_query_multiple_filters(fs_store):
@@ -487,7 +516,7 @@ def test_filesystem_store_query_multiple_filters(fs_store):
 
 def test_filesystem_store_query_dont_include_type_folder(fs_store):
     results = fs_store.query(stix2.Filter("type", "!=", "tool"))
-    assert len(results) == 28
+    assert len(results) == 29
 
 
 def test_filesystem_store_add(fs_store):
@@ -572,6 +601,26 @@ def test_filesystem_store_add_marking(fs_store):
     assert marking_r["definition"]["tlp"] == "green"
 
     os.remove(marking_filepath)
+
+
+def test_filesystem_store_add_sco(fs_store):
+    sco = stix2.v21.EmailAddress(
+        value="jdoe@example.com",
+    )
+
+    fs_store.add(sco)
+    sco_filepath = os.path.join(
+        FS_PATH, "email-addr", sco["id"] + ".json",
+    )
+
+    assert os.path.exists(sco_filepath)
+
+    sco_r = fs_store.get(sco["id"])
+    assert sco_r["id"] == sco["id"]
+    assert sco_r["value"] == sco["value"]
+
+    os.remove(sco_filepath)
+    os.rmdir(os.path.dirname(sco_filepath))
 
 
 def test_filesystem_object_with_custom_property(fs_store):
@@ -1024,6 +1073,7 @@ def test_search_auth_set_black_empty(rel_fs_store):
         "attack-pattern",
         "campaign",
         "course-of-action",
+        "directory",
         "identity",
         "indicator",
         "intrusion-set",


### PR DESCRIPTION
Fixes #341 

I changed the implementation analogously to what I did in PR #342 for the memory store: upon storage, the `modified` property is checked for to determine whether the object type is versioned.  Upon reading/querying, the storage implementation itself is checked to see whether versioning was activated when the object was added.  That decision had to have been made with the object was added in order to activate the proper bookkeeping, so it makes sense that we should be able to "remember" that decision for future queries.

In this case, instead of checking in-memory bookkeeping data structures like was done with the memory backend, we must check the filesystem.  It is implemented as follows: if there exists a subdirectory in the object type directory which is named like "\<type\>--\<uuid\>", then the type is treated as versioned.  This will mis-classify empty versioned type directories, but there will be no results regardless, so it doesn't actually matter.

As before, all references to markings are gone since they are no longer the lone unversioned special case STIX object.  I kept markings tests in the unit test suite though, and added some new unit tests which use SCOs.  I also added an SCO directory and JSON file to the data directory used for the tests.