### PR TITLE
Fix the pattern AST creation function

### DIFF
--- a/stix2/pattern_visitor.py
+++ b/stix2/pattern_visitor.py
@@ -1,11 +1,7 @@
 import importlib
 import inspect
 
-from antlr4 import BailErrorStrategy, CommonTokenStream, InputStream
-import antlr4.error.Errors
-import six
-from stix2patterns.exceptions import ParseException, ParserErrorListener
-from stix2patterns.grammars.STIXPatternLexer import STIXPatternLexer
+from stix2patterns.exceptions import ParseException
 from stix2patterns.grammars.STIXPatternParser import (
     STIXPatternParser, TerminalNode,
 )

--- a/stix2/test/v21/test_indicator.py
+++ b/stix2/test/v21/test_indicator.py
@@ -271,7 +271,7 @@ def test_indicator_stix20_invalid_pattern():
         )
 
     assert excinfo.value.cls == stix2.v21.Indicator
-    assert "FAIL: The same qualifier is used more than once" in str(excinfo.value)
+    assert "FAIL: Duplicate qualifier type encountered" in str(excinfo.value)
 
     ind = stix2.v21.Indicator(
         type="indicator",

--- a/stix2/test/v21/test_pattern_expressions.py
+++ b/stix2/test/v21/test_pattern_expressions.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytest
+from stix2patterns.exceptions import ParseException
 
 import stix2
 from stix2.pattern_visitor import create_pattern_object
@@ -515,3 +516,8 @@ def test_list_constant():
 def test_parsing_multiple_slashes_quotes():
     patt_obj = create_pattern_object("[ file:name = 'weird_name\\'' ]")
     assert str(patt_obj) == "[file:name = 'weird_name\\'']"
+
+
+def test_parse_error():
+    with pytest.raises(ParseException):
+        create_pattern_object("[ file: name = 'weirdname]")


### PR DESCRIPTION
Fixes #326 

It seems like [stix2.pattern_visitor.create_pattern_object()](https://github.com/oasis-open/cti-python-stix2/blob/8aca39a0b037647f055ad11c85e0f289835f9f3d/stix2/pattern_visitor.py#L329) was written based on a copy-paste of a function from the pattern validator.  But it wasn't changed enough.  I fixed it up:

- The docstring still mentioned validation.  That's not what the function does.  It was totally wrong.  I gave it a better one.
- That `pattern[:2]` junk was from the validator checking whether the pattern starts with brackets.  It doesn't belong in the AST builder.  I removed it.
- An error listener was used which produced messages with "FAIL:".  That makes sense in the context of validation, but not here.  There is no success/fail test happening.  I switched to a different error listener which produces a more appropriate message.
- I did an ANTLR parser setup similar to the pattern matcher, with BailErrorStrategy and the appropriate error handling, so that parse errors result in exceptions with sensible error messages.

If we want to make visitor use more convenient, maybe we should give the Pattern class(es) from the pattern validator a `visit()` method analogous to the [walk()](https://github.com/oasis-open/cti-pattern-validator/blob/969b9abf60f3e7874d612a43ca2f94b7d4593702/stix2patterns/v21/pattern.py#L36) method?

An example of error output now (with Python 3):
```
Traceback (most recent call last):
  File "c:\programming\python\stix\pattern-validator\stix2patterns\v20\grammars\STIXPatternParser.py", line 2090, in primitiveLiteral
    raise NoViableAltException(self)
antlr4.error.Errors.NoViableAltException: None

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "testx_pattern_parse.py", line 3, in <module>
    errs = create_pattern_object(pattern="[ file: name = 'weirdname]")
  File "C:\Programming\python\stix\cti-python-stix2\stix2\pattern_visitor.py", line 363, in create_pattern_object
    six.raise_from(
  File "<string>", line 3, in raise_from
stix2patterns.exceptions.ParseException: 1:15: no viable alternative at input '''
```