### PR TITLE
Add the "sample_ref" property to malware-analysis SDOs

### DIFF
--- a/stix2/test/v21/test_malware_analysis.py
+++ b/stix2/test/v21/test_malware_analysis.py
@@ -38,7 +38,8 @@ MALWARE_ANALYSIS_JSON = """{
     "analysis_sco_refs": [
         "file--fc27e371-6c88-4c5c-868a-4dda0e60b167",
         "url--6f7a74cd-8eb2-4b88-a4da-aa878e50ac2e"
-    ]
+    ],
+    "sample_ref": "email-addr--499a32d7-74c1-4276-ace9-725ac933e243"
 }"""
 
 

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -526,6 +526,7 @@ class MalwareAnalysis(STIXDomainObject):
         ('analysis_ended', TimestampProperty()),
         ('av_result', StringProperty()),
         ('analysis_sco_refs', ListProperty(ReferenceProperty(valid_types="SCO", spec_version='2.1'))),
+        ('sample_ref', ReferenceProperty(valid_types="SCO", spec_version="2.1")),
     ])
 
     def _check_object_constraints(self):


### PR DESCRIPTION
From https://github.com/oasis-tcs/cti-stix2/issues/210
Fixes half of #339 .