### PR TITLE
Update malware-analysis SDO's av_result property

### DIFF
--- a/stix2/test/v21/test_malware_analysis.py
+++ b/stix2/test/v21/test_malware_analysis.py
@@ -34,7 +34,8 @@ MALWARE_ANALYSIS_JSON = """{
     "submitted": "2018-11-23T06:45:55.747Z",
     "analysis_started": "2018-11-29T07:30:03.895Z",
     "analysis_ended": "2018-11-29T08:30:03.895Z",
-    "av_result": "malicious",
+    "result_name": "MegaRansom",
+    "result": "malicious",
     "analysis_sco_refs": [
         "file--fc27e371-6c88-4c5c-868a-4dda0e60b167",
         "url--6f7a74cd-8eb2-4b88-a4da-aa878e50ac2e"

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -524,14 +524,15 @@ class MalwareAnalysis(STIXDomainObject):
         ('submitted', TimestampProperty()),
         ('analysis_started', TimestampProperty()),
         ('analysis_ended', TimestampProperty()),
-        ('av_result', StringProperty()),
+        ('result_name', StringProperty()),
+        ('result', StringProperty()),
         ('analysis_sco_refs', ListProperty(ReferenceProperty(valid_types="SCO", spec_version='2.1'))),
     ])
 
     def _check_object_constraints(self):
         super(MalwareAnalysis, self)._check_object_constraints()
 
-        self._check_at_least_one_property(["av_result", "analysis_sco_refs"])
+        self._check_at_least_one_property(["result", "analysis_sco_refs"])
 
 
 class Note(STIXDomainObject):


### PR DESCRIPTION
From https://github.com/oasis-tcs/cti-stix2/issues/213
Fixes half of #339 .

Replace the `av_result` property with `result` and `result_name` properties.
