### PR TITLE
Add parent_directory_ref as an ID contributing property for file SCOs

### DIFF
--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -382,7 +382,7 @@ class File(_Observable):
         ('granular_markings', ListProperty(GranularMarking)),
         ('defanged', BooleanProperty(default=lambda: False)),
     ])
-    _id_contributing_properties = ["hashes", "name", "extensions"]
+    _id_contributing_properties = ["hashes", "name", "parent_directory_ref", "extensions"]
 
     def _check_object_constraints(self):
         super(File, self)._check_object_constraints()


### PR DESCRIPTION
Fixes #361 

I didn't add a unit test for this, just added the property name to the contributing property list.  There were no unit tests for specific SCOs, just the general deterministic ID machinery, so perhaps it isn't necessary.