### PR TITLE
New STIX 2.1 SCO extension name requirement: must end with "-ext"

### DIFF
--- a/stix2/core.py
+++ b/stix2/core.py
@@ -7,10 +7,10 @@ import re
 
 import stix2
 
-from .base import _STIXBase
+from .base import _Observable, _STIXBase
 from .exceptions import ParseError
 from .markings import _MarkingsMixin
-from .utils import _get_dict
+from .utils import SCO21_EXT_REGEX, TYPE_REGEX, _get_dict
 
 STIX2_OBJ_MAPS = {}
 
@@ -258,22 +258,54 @@ def _register_observable(new_observable, version=None):
     OBJ_MAP_OBSERVABLE[new_observable._type] = new_observable
 
 
-def _register_observable_extension(observable, new_extension, version=None):
+def _register_observable_extension(
+    observable, new_extension, version=stix2.DEFAULT_VERSION
+):
     """Register a custom extension to a STIX Cyber Observable type.
 
     Args:
-        observable: An observable object
+        observable: An observable class or instance
         new_extension (class): A class to register in the Observables
             Extensions map.
-        version (str): Which STIX2 version to use. (e.g. "2.0", "2.1"). If
-            None, use latest version.
+        version (str): Which STIX2 version to use. (e.g. "2.0", "2.1").
+            Defaults to the latest supported version.
 
     """
-    if version:
-        v = 'v' + version.replace('.', '')
-    else:
-        # Use default version (latest) if no version was provided.
-        v = 'v' + stix2.DEFAULT_VERSION.replace('.', '')
+    obs_class = observable if isinstance(observable, type) else \
+        type(observable)
+    ext_type = new_extension._type
+
+    if not issubclass(obs_class, _Observable):
+        raise ValueError("'observable' must be a valid Observable class!")
+
+    if version == "2.0":
+        if not re.match(TYPE_REGEX, ext_type):
+            raise ValueError(
+                "Invalid extension type name '%s': must only contain the "
+                "characters a-z (lowercase ASCII), 0-9, and hyphen (-)." %
+                ext_type,
+            )
+    else:  # 2.1+
+        if not re.match(SCO21_EXT_REGEX, ext_type):
+            raise ValueError(
+                "Invalid extension type name '%s': must only contain the "
+                "characters a-z (lowercase ASCII), 0-9, hyphen (-), and end "
+                "with '-ext'." % ext_type,
+            )
+
+    if len(ext_type) < 3 or len(ext_type) > 250:
+        raise ValueError(
+            "Invalid extension type name '%s': must be between 3 and 250"
+            " characters." % ext_type,
+        )
+
+    if not new_extension._properties:
+        raise ValueError(
+            "Invalid extension: must define at least one property: " +
+            ext_type,
+        )
+
+    v = 'v' + version.replace('.', '')
 
     try:
         observable_type = observable._type
@@ -287,7 +319,7 @@ def _register_observable_extension(observable, new_extension, version=None):
     EXT_MAP = STIX2_OBJ_MAPS[v]['observable-extensions']
 
     try:
-        EXT_MAP[observable_type][new_extension._type] = new_extension
+        EXT_MAP[observable_type][ext_type] = new_extension
     except KeyError:
         if observable_type not in OBJ_MAP_OBSERVABLE:
             raise ValueError(
@@ -296,7 +328,7 @@ def _register_observable_extension(observable, new_extension, version=None):
                 % observable_type,
             )
         else:
-            EXT_MAP[observable_type] = {new_extension._type: new_extension}
+            EXT_MAP[observable_type] = {ext_type: new_extension}
 
 
 def _collect_stix2_mappings():

--- a/stix2/core.py
+++ b/stix2/core.py
@@ -259,7 +259,7 @@ def _register_observable(new_observable, version=None):
 
 
 def _register_observable_extension(
-    observable, new_extension, version=stix2.DEFAULT_VERSION
+    observable, new_extension, version=stix2.DEFAULT_VERSION,
 ):
     """Register a custom extension to a STIX Cyber Observable type.
 

--- a/stix2/test/v20/test_custom.py
+++ b/stix2/test/v20/test_custom.py
@@ -821,27 +821,24 @@ def test_custom_extension_invalid_type_name():
 
 
 def test_custom_extension_no_properties():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         @stix2.v20.CustomExtension(stix2.v20.DomainName, 'x-new-ext2', None)
         class BarExtension():
             pass
-    assert "Must supply a list, containing tuples." in str(excinfo.value)
 
 
 def test_custom_extension_empty_properties():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         @stix2.v20.CustomExtension(stix2.v20.DomainName, 'x-new-ext2', [])
         class BarExtension():
             pass
-    assert "Must supply a list, containing tuples." in str(excinfo.value)
 
 
 def test_custom_extension_dict_properties():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         @stix2.v20.CustomExtension(stix2.v20.DomainName, 'x-new-ext2', {})
         class BarExtension():
             pass
-    assert "Must supply a list, containing tuples." in str(excinfo.value)
 
 
 def test_custom_extension_no_init_1():

--- a/stix2/test/v21/test_custom.py
+++ b/stix2/test/v21/test_custom.py
@@ -800,7 +800,7 @@ def test_custom_extension_wrong_observable_type():
 )
 def test_custom_extension_with_list_and_dict_properties_observable_type(data):
     @stix2.v21.CustomExtension(
-        stix2.v21.UserAccount, 'some-extension', [
+        stix2.v21.UserAccount, 'some-extension-ext', [
             ('keys', stix2.properties.ListProperty(stix2.properties.DictionaryProperty, required=True)),
         ],
     )
@@ -876,32 +876,29 @@ def test_custom_extension_invalid_type_name():
 
 
 def test_custom_extension_no_properties():
-    with pytest.raises(ValueError) as excinfo:
-        @stix2.v21.CustomExtension(stix2.v21.DomainName, 'x-new-ext2', None)
+    with pytest.raises(ValueError):
+        @stix2.v21.CustomExtension(stix2.v21.DomainName, 'x-new2-ext', None)
         class BarExtension():
             pass
-    assert "Must supply a list, containing tuples." in str(excinfo.value)
 
 
 def test_custom_extension_empty_properties():
-    with pytest.raises(ValueError) as excinfo:
-        @stix2.v21.CustomExtension(stix2.v21.DomainName, 'x-new-ext2', [])
+    with pytest.raises(ValueError):
+        @stix2.v21.CustomExtension(stix2.v21.DomainName, 'x-new2-ext', [])
         class BarExtension():
             pass
-    assert "Must supply a list, containing tuples." in str(excinfo.value)
 
 
 def test_custom_extension_dict_properties():
-    with pytest.raises(ValueError) as excinfo:
-        @stix2.v21.CustomExtension(stix2.v21.DomainName, 'x-new-ext2', {})
+    with pytest.raises(ValueError):
+        @stix2.v21.CustomExtension(stix2.v21.DomainName, 'x-new2-ext', {})
         class BarExtension():
             pass
-    assert "Must supply a list, containing tuples." in str(excinfo.value)
 
 
 def test_custom_extension_no_init_1():
     @stix2.v21.CustomExtension(
-        stix2.v21.DomainName, 'x-new-extension', [
+        stix2.v21.DomainName, 'x-new-extension-ext', [
             ('property1', stix2.properties.StringProperty(required=True)),
         ],
     )
@@ -914,7 +911,7 @@ def test_custom_extension_no_init_1():
 
 def test_custom_extension_no_init_2():
     @stix2.v21.CustomExtension(
-        stix2.v21.DomainName, 'x-new-ext2', [
+        stix2.v21.DomainName, 'x-new2-ext', [
             ('property1', stix2.properties.StringProperty(required=True)),
         ],
     )
@@ -949,14 +946,14 @@ def test_custom_and_spec_extension_mix():
     file_obs = stix2.v21.File(
         name="my_file.dat",
         extensions={
-            "x-custom1": {
+            "custom1-ext": {
                 "a": 1,
                 "b": 2,
             },
             "ntfs-ext": {
                 "sid": "S-1-whatever",
             },
-            "x-custom2": {
+            "custom2-ext": {
                 "z": 99.9,
                 "y": False,
             },
@@ -969,8 +966,8 @@ def test_custom_and_spec_extension_mix():
         allow_custom=True,
     )
 
-    assert file_obs.extensions["x-custom1"] == {"a": 1, "b": 2}
-    assert file_obs.extensions["x-custom2"] == {"y": False, "z": 99.9}
+    assert file_obs.extensions["custom1-ext"] == {"a": 1, "b": 2}
+    assert file_obs.extensions["custom2-ext"] == {"y": False, "z": 99.9}
     assert file_obs.extensions["ntfs-ext"].sid == "S-1-whatever"
     assert file_obs.extensions["raster-image-ext"].image_height == 1024
 

--- a/stix2/test/v21/test_custom.py
+++ b/stix2/test/v21/test_custom.py
@@ -800,7 +800,7 @@ def test_custom_extension_wrong_observable_type():
 )
 def test_custom_extension_with_list_and_dict_properties_observable_type(data):
     @stix2.v21.CustomExtension(
-        stix2.v21.UserAccount, 'some-extension-ext', [
+        stix2.v21.UserAccount, 'x-some-extension-ext', [
             ('keys', stix2.properties.ListProperty(stix2.properties.DictionaryProperty, required=True)),
         ],
     )
@@ -946,14 +946,14 @@ def test_custom_and_spec_extension_mix():
     file_obs = stix2.v21.File(
         name="my_file.dat",
         extensions={
-            "custom1-ext": {
+            "x-custom1-ext": {
                 "a": 1,
                 "b": 2,
             },
             "ntfs-ext": {
                 "sid": "S-1-whatever",
             },
-            "custom2-ext": {
+            "x-custom2-ext": {
                 "z": 99.9,
                 "y": False,
             },
@@ -966,8 +966,8 @@ def test_custom_and_spec_extension_mix():
         allow_custom=True,
     )
 
-    assert file_obs.extensions["custom1-ext"] == {"a": 1, "b": 2}
-    assert file_obs.extensions["custom2-ext"] == {"y": False, "z": 99.9}
+    assert file_obs.extensions["x-custom1-ext"] == {"a": 1, "b": 2}
+    assert file_obs.extensions["x-custom2-ext"] == {"y": False, "z": 99.9}
     assert file_obs.extensions["ntfs-ext"].sid == "S-1-whatever"
     assert file_obs.extensions["raster-image-ext"].image_height == 1024
 

--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -26,6 +26,7 @@ NOW = object()
 STIX_UNMOD_PROPERTIES = ['created', 'created_by_ref', 'id', 'type']
 
 TYPE_REGEX = r'^\-?[a-z0-9]+(-[a-z0-9]+)*\-?$'
+SCO21_EXT_REGEX = r'^\-?[a-z0-9]+(-[a-z0-9]+)*\-ext$'
 
 
 class STIXdatetime(dt.datetime):


### PR DESCRIPTION
Fixes #364 

I made more changes than you may think was strictly necessary, but I thought some aspects of the custom SCO extension code needed some improvement.

- Most requirements on SCO extensions were checked in `_custom_extension_builder`, which is the implementation for the `CustomExtension` decorators (both 2.0 and 2.1).  The former called `_register_observable_extension` to enable the extension.  So you could bypass most STIX2 requirements by bypassing the decorator and builder function and registering an extension directly.  I decided that was undesirable, so I moved all of the requirement checking into the register function.
- Some of the aforementioned checking was for some reason embedded inside the dynamically created extension subclass (`_CustomExtension`), which didn't make any sense and cluttered up the class.  So a side effect of the above is that the class is a lot cleaner and clearer now.
- The custom extension decorator's `properties` had previously been documented as requiring a list of tuples.  That seemed unnecessarily restrictive, so I changed the check to a more sensible one (I thought), and changed the exception message for a violation.  Really, all you ever needed was something you can turn into a dict via `OrderedDict(...)`, which includes any mapping, as well as iterables of length-2-iterables (e.g. tuples of tuples, lists of lists, etc).  One might argue that allowing unordered mappings means property order might be unpredictable.  But if that's important, people don't have to use those types (and we never do that).  I think the added flexibility is fine.
- Changing the exception message broke several unit tests which were checking message contents.  I removed the message checks.  The important thing is that the exception is being thrown.
- Since the SCO extension name syntax rules are now different between STIX 2.0 and 2.1, I had to ensure that both rulesets were checked as appropriate.  The existing code had a regex; I added a special second regex for 2.1+ SCO's which hopefully enforces the correct requirements (it's basically the same as the old one but with "-ext" at the end).  The extension registration function now has to check the STIX version and choose the right regex to use.
- The `version` default changed in the registration function.  I needed a version so I could choose the right SCO extension name regex.  `None` doesn't fit the bill, but the `stix2.DEFAULT_VERSION` does, and is immutable.  The code already behaved that way, but didn't use the obvious implementation, so I simplified it and made my life easier.
- Many 2.1 unit tests used SCO extension names which became invalid, so I had to make up valid ones.  I tried to make them similar to the old ones.