### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 cache: pip
-dist: xenial
+dist: bionic
 python:
   - "2.7"
   - "3.4"

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,6 @@ setup(
     },
     extras_require={
         'taxii': ['taxii2-client'],
-        'semantic': ['haversine', 'fuzzywuzzy'],
+        'semantic': ['haversine', 'rapidfuzz'],
     },
 )

--- a/stix2/environment.py
+++ b/stix2/environment.py
@@ -364,7 +364,7 @@ def partial_string_based(str1, str2):
 
     """
     from rapidfuzz import fuzz
-    result = fuzz.token_sort_ratio(str1, str2)
+    result = round(fuzz.token_sort_ratio(str1, str2))
     logger.debug("--\t\tpartial_string_based '%s' '%s'\tresult: '%s'", str1, str2, result)
     return result / 100.0
 

--- a/stix2/environment.py
+++ b/stix2/environment.py
@@ -363,8 +363,8 @@ def partial_string_based(str1, str2):
         float: Number between 0.0 and 1.0 depending on match criteria.
 
     """
-    from fuzzywuzzy import fuzz
-    result = fuzz.token_sort_ratio(str1, str2, force_ascii=False)
+    from rapidfuzz import fuzz
+    result = fuzz.token_sort_ratio(str1, str2)
     logger.debug("--\t\tpartial_string_based '%s' '%s'\tresult: '%s'", str1, str2, result)
     return result / 100.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,8 @@ deps =
   pytest-cov
   coverage
   taxii2-client
-  fuzzywuzzy
+  rapidfuzz
   haversine
-  python-Levenshtein
   medallion
 commands =
   python -m pytest --cov=stix2 stix2/test/ --cov-report term-missing -W ignore::stix2.exceptions.STIXDeprecationWarning


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.