### PR TITLE
Use a fast ISO8601 date time parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     keywords='stix stix2 json cti cyber threat intelligence',
     packages=find_packages(exclude=['*.test', '*.test.*']),
     install_requires=[
+        'ciso8601',
         'enum34 ; python_version<"3.4"',
         'python-dateutil',
         'pytz',

--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -14,6 +14,7 @@ from dateutil import parser
 import pytz
 import six
 
+from ciso8601 import parse_datetime
 import stix2
 
 from .exceptions import (
@@ -253,7 +254,10 @@ def parse_into_datetime(
     else:
         # value isn't a date or datetime object so assume it's a string
         try:
-            parsed = parser.parse(value)
+            try:
+                parsed = parse_datetime(value)
+            except ValueError:
+                parsed = parser.parse(value)
         except (TypeError, ValueError):
             # Unknown format
             raise ValueError(


### PR DESCRIPTION
# Problem to Solve

Stix parsing is slow.

# Troubleshooting 

Profiling `stix2.parse`:

```py
from stix2 import parse
def test():
    with open('enterprise-attack.json') as f:
        parse(f, allow_custom=True)

    with open('pre-attack.json') as f:
        parse(f, allow_custom=True)

    with open('stix-capec.json') as f:
        parse(f, allow_custom=True)
```
41% of execution time is used by `dateutil.parser` :
![image](https://user-images.githubusercontent.com/31675/78937058-1302ba00-7ab0-11ea-9fd7-af3eb96b1225.png)



Python `dateutil.parser.parse()` is slow! 

# Proposed Solution 

Try string parsing into a `datetime` object with `ciso8601`, a fast ISO8601 date time parser for Python written in C. 

As `ciso8601` only supports the most common subset of ISO 8601, if it fails, try again with the slow `dateutil.parser.parse()`. 

# Performance 

```py
from stix2 import parse

def test():
    with open('enterprise-attack.json') as f:
        parse(f, allow_custom=True)

    with open('pre-attack.json') as f:
        parse(f, allow_custom=True)

    with open('stix-capec.json') as f:
        parse(f, allow_custom=True)

if __name__ == '__main__':
    import timeit
    print(timeit.timeit("test()", number=10, setup="from __main__ import test"))

```

Before:
```console
$ python testcase.py 
16.522664724034257
```
After:
```console
$ python testcase.py 
37.800530530977994
```

Profiling after (without timeit):

![image](https://user-images.githubusercontent.com/31675/78938053-d637c280-7ab1-11ea-8769-3b070c204de6.png)

# Additional Information
* https://github.com/closeio/ciso8601

