### PR TITLE
Fix star-imports from stix2.v20 and v21

### DIFF
--- a/stix2/v20/__init__.py
+++ b/stix2/v20/__init__.py
@@ -103,3 +103,33 @@ EXT_MAP = {
         'unix-account-ext': UNIXAccountExt,
     },
 }
+
+
+# Ensure star-imports from this module get the right symbols.  "base" is a
+# known problem, since there are multiple modules with that name and one can
+# accidentally overwrite another.
+__all__ = """
+    Bundle,
+
+    TLP_AMBER, TLP_GREEN, TLP_RED, TLP_WHITE, CustomMarking, ExternalReference,
+    GranularMarking, KillChainPhase, MarkingDefinition, StatementMarking,
+    TLPMarking,
+
+    URL, AlternateDataStream, ArchiveExt, Artifact, AutonomousSystem,
+    CustomExtension, CustomObservable, Directory, DomainName, EmailAddress,
+    EmailMessage, EmailMIMEComponent, File, HTTPRequestExt, ICMPExt,
+    IPv4Address, IPv6Address, MACAddress, Mutex, NetworkTraffic, NTFSExt,
+    PDFExt, Process, RasterImageExt, SocketExt, Software, TCPExt,
+    UNIXAccountExt, UserAccount, WindowsPEBinaryExt,
+    WindowsPEOptionalHeaderType, WindowsPESection, WindowsProcessExt,
+    WindowsRegistryKey, WindowsRegistryValueType, WindowsServiceExt,
+    X509Certificate, X509V3ExtenstionsType,
+
+    AttackPattern, Campaign, CourseOfAction, CustomObject, Identity, Indicator,
+    IntrusionSet, Malware, ObservedData, Report, ThreatActor, Tool,
+    Vulnerability,
+
+    Relationship, Sighting,
+
+    OBJ_MAP, OBJ_MAP_OBSERVABLE, EXT_MAP
+""".replace(",", " ").split()

--- a/stix2/v21/__init__.py
+++ b/stix2/v21/__init__.py
@@ -111,3 +111,34 @@ EXT_MAP = {
         'unix-account-ext': UNIXAccountExt,
     },
 }
+
+
+# Ensure star-imports from this module get the right symbols.  "base" is a
+# known problem, since there are multiple modules with that name and one can
+# accidentally overwrite another.
+__all__ = """
+    Bundle,
+
+    TLP_AMBER, TLP_GREEN, TLP_RED, TLP_WHITE, CustomMarking, ExternalReference,
+    GranularMarking, KillChainPhase, LanguageContent, MarkingDefinition,
+    StatementMarking, TLPMarking,
+
+    URL, AlternateDataStream, ArchiveExt, Artifact, AutonomousSystem,
+    CustomExtension, CustomObservable, Directory, DomainName, EmailAddress,
+    EmailMessage, EmailMIMEComponent, File, HTTPRequestExt, ICMPExt,
+    IPv4Address, IPv6Address, MACAddress, Mutex, NetworkTraffic, NTFSExt,
+    PDFExt, Process, RasterImageExt, SocketExt, Software, TCPExt,
+    UNIXAccountExt, UserAccount, WindowsPEBinaryExt,
+    WindowsPEOptionalHeaderType, WindowsPESection, WindowsProcessExt,
+    WindowsRegistryKey, WindowsRegistryValueType, WindowsServiceExt,
+    X509Certificate, X509V3ExtenstionsType,
+
+    AttackPattern, Campaign, CourseOfAction, CustomObject, Grouping, Identity,
+    Indicator, Infrastructure, IntrusionSet, Location, Malware,
+    MalwareAnalysis, Note, ObservedData, Opinion, Report, ThreatActor, Tool,
+    Vulnerability,
+
+    Relationship, Sighting,
+
+    OBJ_MAP, OBJ_MAP_OBSERVABLE, EXT_MAP
+""".replace(",", " ").split()


### PR DESCRIPTION
Fixes #399 .

stix2/\_\_init\_\_.py currently does a star-import from stix2.v20.  Unfortunately that brings in a "base" symbol which becomes stix2.base, and hides the actual stix2/base.py module.  This PR adds `__all__`s to the v20 and v21 modules which explicitly lists what symbols should be imported, so we don't get "base" by mistake from them.

(Impl note: the text block split() technique makes it easier to keep the \_\_all\_\_ lists up-to-date, because you can just copy-paste the symbol lists from the imports above.)