### PR TITLE
Change ObjectReferenceProperty to ReferenceProperty in 2.1 SCO classes

### DIFF
--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -900,6 +900,27 @@ def test_file_example_with_RasterImageExt_Object():
     assert f.extensions["raster-image-ext"].exif_tags["XResolution"] == 4928
 
 
+def test_file_with_archive_ext_object():
+    ad = stix2.v21.Directory(path="archived/path")
+    f_obj = stix2.v21.File(
+        name="foo", extensions={
+            "archive-ext": {
+                "contains_refs": [ad, ],
+            },
+        },
+    )
+    f_ref = stix2.v21.File(
+        name="foo", extensions={
+            "archive-ext": {
+                "contains_refs": [ad.id, ],
+            },
+        },
+    )
+
+    assert f_obj["id"] == f_ref["id"]
+    assert f_obj["extensions"]["archive-ext"]["contains_refs"][0] == ad["id"]
+
+
 RASTER_IMAGE_EXT = """{
 "type": "observed-data",
 "spec_version": "2.1",

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -14,8 +14,7 @@ from ..properties import (
     BinaryProperty, BooleanProperty, DictionaryProperty,
     EmbeddedObjectProperty, EnumProperty, ExtensionsProperty, FloatProperty,
     HashesProperty, HexProperty, IDProperty, IntegerProperty, ListProperty,
-    ObjectReferenceProperty, ReferenceProperty, StringProperty,
-    TimestampProperty, TypeProperty,
+    ReferenceProperty, StringProperty, TimestampProperty, TypeProperty,
 )
 from .base import _Extension, _Observable, _STIXBase21
 from .common import GranularMarking
@@ -144,7 +143,7 @@ class EmailMIMEComponent(_STIXBase21):
 
     _properties = OrderedDict([
         ('body', StringProperty()),
-        ('body_raw_ref', ObjectReferenceProperty(valid_types=['artifact', 'file'])),
+        ('body_raw_ref', ReferenceProperty(valid_types=['artifact', 'file'], spec_version="2.1")),
         ('content_type', StringProperty()),
         ('content_disposition', StringProperty()),
     ])
@@ -201,7 +200,7 @@ class ArchiveExt(_Extension):
 
     _type = 'archive-ext'
     _properties = OrderedDict([
-        ('contains_refs', ListProperty(ObjectReferenceProperty(valid_types=['file', 'directory']), required=True)),
+        ('contains_refs', ListProperty(ReferenceProperty(valid_types=['file', 'directory'], spec_version="2.1"), required=True)),
         ('comment', StringProperty()),
     ])
 
@@ -465,7 +464,7 @@ class HTTPRequestExt(_Extension):
         ('request_version', StringProperty()),
         ('request_header', DictionaryProperty(spec_version='2.1')),
         ('message_body_length', IntegerProperty()),
-        ('message_body_data_ref', ObjectReferenceProperty(valid_types='artifact')),
+        ('message_body_data_ref', ReferenceProperty(valid_types='artifact', spec_version="2.1")),
     ])
 
 
@@ -654,7 +653,7 @@ class WindowsServiceExt(_Extension):
                 "SERVICE_SYSTEM_ALERT",
             ]),
         ),
-        ('service_dll_refs', ListProperty(ObjectReferenceProperty(valid_types='file'))),
+        ('service_dll_refs', ListProperty(ReferenceProperty(valid_types='file', spec_version="2.1"))),
         (
             'service_type', EnumProperty(allowed=[
                 "SERVICE_KERNEL_DRIVER",


### PR DESCRIPTION
Fixes #403

Also add a unit test to ensure that when a stix2 object is passed as a value of a ReferenceProperty of a 2.1 SCO, that the ID is properly pulled out and used as the actual property value, and that it doesn't affect the deterministic ID calculation.