### PR TITLE
Semantic Equivalence - partial_string_based()

### DIFF
--- a/stix2/environment.py
+++ b/stix2/environment.py
@@ -365,7 +365,7 @@ def partial_string_based(str1, str2):
 
     """
     from rapidfuzz import fuzz
-    result = round(fuzz.token_sort_ratio(str1, str2))
+    result = fuzz.token_sort_ratio(str1, str2)
     logger.debug("--\t\tpartial_string_based '%s' '%s'\tresult: '%s'", str1, str2, result)
     return result / 100.0
 

--- a/stix2/test/v21/test_environment.py
+++ b/stix2/test/v21/test_environment.py
@@ -787,7 +787,7 @@ def test_semantic_equivalence_prop_scores():
     tool2 = stix2.v21.Tool(id=TOOL_ID, **TOOL2_KWARGS)
     stix2.Environment().semantically_equivalent(tool1, tool2, prop_scores)
     assert len(prop_scores) == 4
-    assert round(prop_scores["matching_score"], 1) == 8.8
+    assert round(prop_scores["matching_score"], 1) == 8.9
     assert round(prop_scores["sum_weights"], 1) == 100.0
 
 


### PR DESCRIPTION
Remove round call from `fuzz.token_sort_ratio(str1, str2)` call in partial_string_based function.