### PR TITLE
hack for issue_435

### DIFF
--- a/stix2/pattern_visitor.py
+++ b/stix2/pattern_visitor.py
@@ -259,7 +259,7 @@ class STIXPatternVisitorForSTIX2():
             if isinstance(next, TerminalNode):
                 property_path.append(self.instantiate("ListObjectPathComponent", current.property_name, next.getText()))
                 i += 2
-            if isinstance(next, IntegerConstant):
+            elif isinstance(next, IntegerConstant):
                 property_path.append(self.instantiate("ListObjectPathComponent", current.property_name, next.value))
                 i += 2
             else:

--- a/stix2/pattern_visitor.py
+++ b/stix2/pattern_visitor.py
@@ -259,6 +259,9 @@ class STIXPatternVisitorForSTIX2():
             if isinstance(next, TerminalNode):
                 property_path.append(self.instantiate("ListObjectPathComponent", current.property_name, next.getText()))
                 i += 2
+            if isinstance(next, IntegerConstant):
+                property_path.append(self.instantiate("ListObjectPathComponent", current.property_name, next.value))
+                i += 2
             else:
                 property_path.append(current)
                 i += 1

--- a/stix2/patterns.py
+++ b/stix2/patterns.py
@@ -248,7 +248,10 @@ def make_constant(value):
 class _ObjectPathComponent(object):
     @staticmethod
     def create_ObjectPathComponent(component_name):
-        if component_name.endswith("_ref"):
+        # first case is to handle if component_name was quoted
+        if isinstance(component_name, StringConstant):
+            return BasicObjectPathComponent(component_name.value, False)
+        elif component_name.endswith("_ref"):
             return ReferenceObjectPathComponent(component_name)
         elif component_name.find("[") != -1:
             parse1 = component_name.split("[")

--- a/stix2/test/v20/test_pattern_expressions.py
+++ b/stix2/test/v20/test_pattern_expressions.py
@@ -512,13 +512,18 @@ def test_parsing_start_stop_qualified_expression():
 
 
 def test_parsing_mixed_boolean_expression_1():
-    patt_obj = create_pattern_object("[a:b = 1 AND a:b = 2 OR a:b = 3]",)
+    patt_obj = create_pattern_object("[a:b = 1 AND a:b = 2 OR a:b = 3]")
     assert str(patt_obj) == "[a:b = 1 AND a:b = 2 OR a:b = 3]"
 
 
 def test_parsing_mixed_boolean_expression_2():
-    patt_obj = create_pattern_object("[a:b = 1 OR a:b = 2 AND a:b = 3]",)
+    patt_obj = create_pattern_object("[a:b = 1 OR a:b = 2 AND a:b = 3]")
     assert str(patt_obj) == "[a:b = 1 OR a:b = 2 AND a:b = 3]"
+
+
+def test_parsing_integer_index():
+    patt_obj = create_pattern_object("[a:b[1]=2]")
+    assert str(patt_obj) == "[a:b[1] = 2]"
 
 
 def test_parsing_illegal_start_stop_qualified_expression():

--- a/stix2/test/v20/test_pattern_expressions.py
+++ b/stix2/test/v20/test_pattern_expressions.py
@@ -526,6 +526,17 @@ def test_parsing_integer_index():
     assert str(patt_obj) == "[a:b[1] = 2]"
 
 
+# This should never occur, because the first component will always be a property_name, and they should not be quoted.
+def test_parsing_quoted_first_path_component():
+    patt_obj = create_pattern_object("[a:'b'[1]=2]")
+    assert str(patt_obj) == "[a:'b'[1] = 2]"
+
+
+def test_parsing_quoted_second_path_component():
+    patt_obj = create_pattern_object("[a:b.'b'[1]=2]")
+    assert str(patt_obj) == "[a:b.'b'[1] = 2]"
+
+
 def test_parsing_illegal_start_stop_qualified_expression():
     with pytest.raises(ValueError):
         create_pattern_object("[ipv4-addr:value = '1.2.3.4'] START '2016-06-01' STOP '2017-03-12T08:30:00Z'", version="2.0")

--- a/stix2/test/v21/test_pattern_expressions.py
+++ b/stix2/test/v21/test_pattern_expressions.py
@@ -658,6 +658,16 @@ def test_parsing_integer_index():
     patt_obj = create_pattern_object("[a:b[1]=2]")
     assert str(patt_obj) == "[a:b[1] = 2]"
 
+# This should never occur, because the first component will always be a property_name, and they should not be quoted.
+def test_parsing_quoted_first_path_component():
+    patt_obj = create_pattern_object("[a:'b'[1]=2]")
+    assert str(patt_obj) == "[a:'b'[1] = 2]"
+
+
+def test_parsing_quoted_second_path_component():
+    patt_obj = create_pattern_object("[a:b.'b'[1]=2]")
+    assert str(patt_obj) == "[a:b.'b'[1] = 2]"
+
 
 def test_parsing_multiple_slashes_quotes():
     patt_obj = create_pattern_object("[ file:name = 'weird_name\\'' ]", version="2.1")

--- a/stix2/test/v21/test_pattern_expressions.py
+++ b/stix2/test/v21/test_pattern_expressions.py
@@ -654,6 +654,11 @@ def test_parsing_mixed_boolean_expression_2():
     assert str(patt_obj) == "[a:b = 1 OR a:b = 2 AND a:b = 3]"
 
 
+def test_parsing_integer_index():
+    patt_obj = create_pattern_object("[a:b[1]=2]")
+    assert str(patt_obj) == "[a:b[1] = 2]"
+
+
 def test_parsing_multiple_slashes_quotes():
     patt_obj = create_pattern_object("[ file:name = 'weird_name\\'' ]", version="2.1")
     assert str(patt_obj) == "[file:name = 'weird_name\\'']"


### PR DESCRIPTION
This is a bit of hack, adding to the original one.  Probably it would be better to change the grammar rule

objectPathComponent
  : <assoc=left> objectPathComponent objectPathComponent  # pathStep
  | '.' (IdentifierWithoutHyphen | StringLiteral)         # keyPathStep
  | LBRACK (IntPosLiteral|IntNegLiteral|ASTERISK) RBRACK  # indexPathStep
  ;

so "a[1]" is reduced to one object instead of two.