### PR TITLE
Version restriction for taxii2client dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'Bug Tracker': 'https://github.com/oasis-open/cti-python-stix2/issues/',
     },
     extras_require={
-        'taxii': ['taxii2-client'],
+        'taxii': ['taxii2-client>=2.2.1'],
         'semantic': ['haversine', 'rapidfuzz'],
     },
 )


### PR DESCRIPTION
Add version restriction to ensure reasonably updated dependency. Pinning to latest version but can be updated with future releases.

```pip install stix2[taxii]```

or they could just

```pip install taxii2client --upgrade```

Related to mitre/cti#103