### PR TITLE
Add a version restriction to the stix2-patterns dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'requests',
         'simplejson',
         'six>=1.13.0',
-        'stix2-patterns',
+        'stix2-patterns>=1.2.0',
     ],
     project_urls={
         'Documentation': 'https://stix2.readthedocs.io/',


### PR DESCRIPTION
Fixes #440 .

Add a version restriction to the stix2-patterns dependency, to ensure users aren't tripped up by old versions.