### PR TITLE
Expose API Reference for Pattern Equivalence - ReadTheDocs

### DIFF
--- a/docs/api/equivalence/patterns/compare/stix2.equivalence.patterns.compare.comparison.rst
+++ b/docs/api/equivalence/patterns/compare/stix2.equivalence.patterns.compare.comparison.rst
@@ -1,0 +1,5 @@
+comparison
+==============
+
+.. automodule:: stix2.equivalence.patterns.compare.comparison
+   :members:

--- a/docs/api/equivalence/patterns/compare/stix2.equivalence.patterns.compare.observation.rst
+++ b/docs/api/equivalence/patterns/compare/stix2.equivalence.patterns.compare.observation.rst
@@ -1,0 +1,5 @@
+observation
+==============
+
+.. automodule:: stix2.equivalence.patterns.compare.observation
+   :members:

--- a/docs/api/equivalence/patterns/transform/stix2.equivalence.patterns.transform.comparison.rst
+++ b/docs/api/equivalence/patterns/transform/stix2.equivalence.patterns.transform.comparison.rst
@@ -1,0 +1,5 @@
+comparison
+==============
+
+.. automodule:: stix2.equivalence.patterns.transform.comparison
+   :members:

--- a/docs/api/equivalence/patterns/transform/stix2.equivalence.patterns.transform.observation.rst
+++ b/docs/api/equivalence/patterns/transform/stix2.equivalence.patterns.transform.observation.rst
@@ -1,0 +1,5 @@
+observation
+==============
+
+.. automodule:: stix2.equivalence.patterns.transform.observation
+   :members:

--- a/docs/api/equivalence/patterns/transform/stix2.equivalence.patterns.transform.specials.rst
+++ b/docs/api/equivalence/patterns/transform/stix2.equivalence.patterns.transform.specials.rst
@@ -1,0 +1,5 @@
+specials
+==============
+
+.. automodule:: stix2.equivalence.patterns.transform.specials
+   :members:

--- a/docs/api/equivalence/stix2.equivalence.patterns.rst
+++ b/docs/api/equivalence/stix2.equivalence.patterns.rst
@@ -1,0 +1,5 @@
+patterns
+==============
+
+.. automodule:: stix2.equivalence.patterns
+   :members:

--- a/docs/api/stix2.equivalence.rst
+++ b/docs/api/stix2.equivalence.rst
@@ -1,0 +1,5 @@
+equivalence
+==============
+
+.. automodule:: stix2.equivalence
+   :members:

--- a/stix2/__init__.py
+++ b/stix2/__init__.py
@@ -6,6 +6,7 @@
    confidence
    datastore
    environment
+   equivalence
    exceptions
    markings
    parsing

--- a/stix2/equivalence/__init__.py
+++ b/stix2/equivalence/__init__.py
@@ -1,0 +1,9 @@
+"""Python APIs for STIX 2 Semantic Equivalence.
+
+.. autosummary::
+   :toctree: equivalence
+
+   patterns
+
+|
+"""

--- a/stix2/equivalence/patterns/__init__.py
+++ b/stix2/equivalence/patterns/__init__.py
@@ -1,3 +1,14 @@
+"""Python APIs for STIX 2 Pattern Semantic Equivalence.
+
+.. autosummary::
+   :toctree: patterns
+
+   compare
+   transform
+
+|
+"""
+
 import stix2
 from stix2.equivalence.patterns.compare.observation import (
     observation_expression_cmp,

--- a/stix2/equivalence/patterns/compare/__init__.py
+++ b/stix2/equivalence/patterns/compare/__init__.py
@@ -1,5 +1,13 @@
 """
 Some generic comparison utility functions.
+
+.. autosummary::
+   :toctree: compare
+
+   comparison
+   observation
+
+|
 """
 
 

--- a/stix2/equivalence/patterns/transform/__init__.py
+++ b/stix2/equivalence/patterns/transform/__init__.py
@@ -1,5 +1,14 @@
 """
 Generic AST transformation classes.
+
+.. autosummary::
+   :toctree: transform
+
+   comparison
+   observation
+   specials
+
+|
 """
 
 


### PR DESCRIPTION
Link to built branch: https://stix2.readthedocs.io/en/api-reference-for-pattern-eq/