### PR TITLE
Fix Location semantic equivalence check for Location objects without the latitude and longitude properties

### DIFF
--- a/stix2/equivalence/object/__init__.py
+++ b/stix2/equivalence/object/__init__.py
@@ -118,7 +118,6 @@ def semantically_equivalent(obj1, obj2, prop_scores={}, **weight_dict):
 def check_property_present(prop, obj1, obj2):
     """Helper method checks if a property is present on both objects."""
     if prop == "longitude_latitude":
-        # if "latitude" in obj1 and "latitude" in obj2 and "longitude" in obj1 and "longitude" in obj2:
         if all(x in obj1 and x in obj2 for x in ['latitude', 'longitude']):
             return True
     elif prop in obj1 and prop in obj2:

--- a/stix2/equivalence/object/__init__.py
+++ b/stix2/equivalence/object/__init__.py
@@ -68,7 +68,7 @@ def semantically_equivalent(obj1, obj2, prop_scores={}, **weight_dict):
             sum_weights = 0.0
 
             for prop in weights[type1]:
-                if check_property_present(prop, obj1, obj2) or prop == "longitude_latitude":
+                if check_property_present(prop, obj1, obj2):
                     w = weights[type1][prop][0]
                     comp_funct = weights[type1][prop][1]
 
@@ -117,7 +117,11 @@ def semantically_equivalent(obj1, obj2, prop_scores={}, **weight_dict):
 
 def check_property_present(prop, obj1, obj2):
     """Helper method checks if a property is present on both objects."""
-    if prop in obj1 and prop in obj2:
+    if prop == "longitude_latitude":
+        # if "latitude" in obj1 and "latitude" in obj2 and "longitude" in obj1 and "longitude" in obj2:
+        if all(x in obj1 and x in obj2 for x in ['latitude', 'longitude']):
+            return True
+    elif prop in obj1 and prop in obj2:
         return True
     return False
 

--- a/stix2/test/v21/test_environment.py
+++ b/stix2/test/v21/test_environment.py
@@ -11,9 +11,9 @@ import stix2.exceptions
 from .constants import (
     ATTACK_PATTERN_ID, ATTACK_PATTERN_KWARGS, CAMPAIGN_ID, CAMPAIGN_KWARGS,
     FAKE_TIME, IDENTITY_ID, IDENTITY_KWARGS, INDICATOR_ID, INDICATOR_KWARGS,
-    LOCATION_ID, MALWARE_ID, MALWARE_KWARGS, RELATIONSHIP_IDS, REPORT_ID,
-    REPORT_KWARGS, THREAT_ACTOR_ID, THREAT_ACTOR_KWARGS, TOOL_ID, TOOL_KWARGS,
-    VULNERABILITY_ID, VULNERABILITY_KWARGS,
+    LOCATION_ID, LOCATION_KWARGS, MALWARE_ID, MALWARE_KWARGS, RELATIONSHIP_IDS,
+    REPORT_ID, REPORT_KWARGS, THREAT_ACTOR_ID, THREAT_ACTOR_KWARGS, TOOL_ID,
+    TOOL_KWARGS, VULNERABILITY_ID, VULNERABILITY_KWARGS,
 )
 
 FS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "stix2_data")
@@ -495,24 +495,32 @@ def test_semantic_equivalence_on_same_indicator():
 
 
 def test_semantic_equivalence_on_same_location1():
-    LOCATION_KWARGS = dict(latitude=45, longitude=179)
-    loc1 = stix2.v21.Location(id=LOCATION_ID, **LOCATION_KWARGS)
-    loc2 = stix2.v21.Location(id=LOCATION_ID, **LOCATION_KWARGS)
+    location_kwargs = dict(latitude=45, longitude=179)
+    loc1 = stix2.v21.Location(id=LOCATION_ID, **location_kwargs)
+    loc2 = stix2.v21.Location(id=LOCATION_ID, **location_kwargs)
     env = stix2.Environment().semantically_equivalent(loc1, loc2)
     assert round(env) == 100
 
 
 def test_semantic_equivalence_on_same_location2():
-    LOCATION_KWARGS = dict(
+    location_kwargs = dict(
         latitude=38.889,
         longitude=-77.023,
         region="northern-america",
         country="us",
     )
-    loc1 = stix2.v21.Location(id=LOCATION_ID, **LOCATION_KWARGS)
-    loc2 = stix2.v21.Location(id=LOCATION_ID, **LOCATION_KWARGS)
+    loc1 = stix2.v21.Location(id=LOCATION_ID, **location_kwargs)
+    loc2 = stix2.v21.Location(id=LOCATION_ID, **location_kwargs)
     env = stix2.Environment().semantically_equivalent(loc1, loc2)
     assert round(env) == 100
+
+
+def test_semantic_equivalence_location_with_no_latlong():
+    loc_kwargs = dict(country="US", administrative_area="US-DC")
+    loc1 = stix2.v21.Location(id=LOCATION_ID, **LOCATION_KWARGS)
+    loc2 = stix2.v21.Location(id=LOCATION_ID, **loc_kwargs)
+    env = stix2.Environment().semantically_equivalent(loc1, loc2)
+    assert round(env) != 100
 
 
 def test_semantic_equivalence_on_same_malware():


### PR DESCRIPTION
Uses contribution from @zrush-mitre (#464).

Fixes #462.