### PR TITLE
Drop 'six' dependency (backwards breaking)

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,7 +10,6 @@ known_third_party =
     pytz,
     requests,
     simplejson,
-    six,
     sphinx,
     stix2patterns,
     taxii2client,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,4 @@ repos:
         args: ["-c", "--diff"]
     -   id: isort
         name: Sort python imports (fixes files)
+exclude: ^stix2/canonicalization/

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ Install with `pip <https://pip.pypa.io/en/stable/>`__:
 
   $ pip install stix2
 
+Note: The library requires Python 3.6+.
+
 Usage
 -----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,6 @@ import os
 import re
 import sys
 
-from six import class_types
 from sphinx.ext.autodoc import ClassDocumenter
 
 from stix2.base import _STIXBase
@@ -107,7 +106,7 @@ class STIXPropertyDocumenter(ClassDocumenter):
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
-        return isinstance(member, class_types) and \
+        return isinstance(member, type) and \
                issubclass(member, _STIXBase) and \
                hasattr(member, '_properties')
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         'pytz',
         'requests',
         'simplejson',
-        'six>=1.13.0',
         'stix2-patterns>=1.2.0',
     ],
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     ],
     keywords='stix stix2 json cti cyber threat intelligence',
     packages=find_packages(exclude=['*.test', '*.test.*']),
+    python_requires='>=3.6',
     install_requires=[
         'pytz',
         'requests',

--- a/stix2/base.py
+++ b/stix2/base.py
@@ -5,7 +5,6 @@ import re
 import uuid
 
 import simplejson as json
-import six
 
 import stix2
 from stix2.canonicalization.Canonicalize import canonicalize
@@ -70,12 +69,9 @@ class _STIXBase(Mapping):
                 # InvalidValueError... so let those propagate.
                 raise
             except Exception as exc:
-                six.raise_from(
-                    InvalidValueError(
-                        self.__class__, prop_name, reason=str(exc),
-                    ),
-                    exc,
-                )
+                raise InvalidValueError(
+                    self.__class__, prop_name, reason=str(exc),
+                ) from exc
 
     # interproperty constraint methods
 
@@ -369,19 +365,8 @@ class _Observable(_STIXBase):
         if json_serializable_object:
 
             data = canonicalize(json_serializable_object, utf8=False)
-
-            # The situation is complicated w.r.t. python 2/3 behavior, so
-            # I'd rather not rely on particular exceptions being raised to
-            # determine what to do.  Better to just check the python version
-            # directly.
-            if six.PY3:
-                uuid_ = uuid.uuid5(SCO_DET_ID_NAMESPACE, data)
-            else:
-                uuid_ = uuid.uuid5(
-                    SCO_DET_ID_NAMESPACE, data.encode("utf-8"),
-                )
-
-            id_ = "{}--{}".format(self._type, six.text_type(uuid_))
+            uuid_ = uuid.uuid5(SCO_DET_ID_NAMESPACE, data)
+            id_ = "{}--{}".format(self._type, str(uuid_))
 
         return id_
 
@@ -447,7 +432,7 @@ def _make_json_serializable(value):
             for v in value
         ]
 
-    elif not isinstance(value, (int, float, six.string_types, bool)):
+    elif not isinstance(value, (int, float, str, bool)):
         # If a "simple" value which is not already JSON-serializable,
         # JSON-serialize to a string and use that as our JSON-serializable
         # value.  This applies to our datetime objects currently (timestamp

--- a/stix2/canonicalization/NumberToJson.py
+++ b/stix2/canonicalization/NumberToJson.py
@@ -21,40 +21,50 @@
 # Convert a Python double/float into an ES6/V8 compatible string #
 ##################################################################
 def convert2Es6Format(value):
-    # Convert double/float to str using the native Python formatter
+# Convert double/float to str using the native Python formatter
     fvalue = float(value)
-
-    # Zero is a special case.  The following line takes "-0" case as well
+#
+# Zero is a special case.  The following line takes "-0" case as well
+#
     if fvalue == 0:
         return '0'
-
-    # The rest of the algorithm works on the textual representation only
+#
+# The rest of the algorithm works on the textual representation only
+#
     pyDouble = str(fvalue)
-
-    # The following line catches the "inf" and "nan" values returned by str(fvalue)
+#
+# The following line catches the "inf" and "nan" values returned by str(fvalue)
+#
     if pyDouble.find('n') >= 0:
         raise ValueError("Invalid JSON number: " + pyDouble)
-
-    # Save sign separately, it doesn't have any role in the algorithm
+#
+# Save sign separately, it doesn't have any role in the algorithm
+#
     pySign = ''
     if pyDouble.find('-') == 0:
         pySign = '-'
         pyDouble = pyDouble[1:]
-
-    # Now we should only have valid non-zero values
+#
+# Now we should only have valid non-zero values
+#
     pyExpStr = ''
     pyExpVal = 0
     q = pyDouble.find('e')
     if q > 0:
-        # Grab the exponent and remove it from the number
+#
+# Grab the exponent and remove it from the number
+#
         pyExpStr = pyDouble[q:]
         if pyExpStr[2:3] == '0':
-            # Supress leading zero on exponents
+#
+# Supress leading zero on exponents
+#
             pyExpStr = pyExpStr[:2] + pyExpStr[3:]
         pyDouble = pyDouble[0:q]
         pyExpVal = int(pyExpStr[1:])
-
-    # Split number in pyFirst + pyDot + pyLast
+#
+# Split number in pyFirst + pyDot + pyLast
+#
     pyFirst = pyDouble
     pyDot = ''
     pyLast = ''
@@ -63,33 +73,40 @@ def convert2Es6Format(value):
         pyDot = '.'
         pyFirst = pyDouble[:q]
         pyLast = pyDouble[q + 1:]
-
-    # Now the string is split into: pySign + pyFirst + pyDot + pyLast + pyExpStr
+#
+# Now the string is split into: pySign + pyFirst + pyDot + pyLast + pyExpStr
+#
     if pyLast == '0':
-        # Always remove trailing .0
+#
+# Always remove trailing .0
+#
         pyDot = ''
         pyLast = ''
-
     if pyExpVal > 0 and pyExpVal < 21:
-        # Integers are shown as is with up to 21 digits
+#
+# Integers are shown as is with up to 21 digits
+#
         pyFirst += pyLast
         pyLast = ''
         pyDot = ''
         pyExpStr = ''
         q = pyExpVal - len(pyFirst)
         while q >= 0:
-            q -= 1
+            q -= 1;
             pyFirst += '0'
     elif pyExpVal < 0 and pyExpVal > -7:
-        # Small numbers are shown as 0.etc with e-6 as lower limit
+#
+# Small numbers are shown as 0.etc with e-6 as lower limit
+#
         pyLast = pyFirst + pyLast
         pyFirst = '0'
         pyDot = '.'
         pyExpStr = ''
         q = pyExpVal
         while q < -1:
-            q += 1
+            q += 1;
             pyLast = '0' + pyLast
-
-    # The resulting sub-strings are concatenated
+#
+# The resulting sub-strings are concatenated
+#
     return pySign + pyFirst + pyDot + pyLast + pyExpStr

--- a/stix2/custom.py
+++ b/stix2/custom.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
 
-import six
-
 from .base import _cls_init
 from .registration import (
     _register_marking, _register_object, _register_observable,
@@ -13,14 +11,11 @@ def _get_properties_dict(properties):
     try:
         return OrderedDict(properties)
     except TypeError as e:
-        six.raise_from(
-            ValueError(
-                "properties must be dict-like, e.g. a list "
-                "containing tuples.  For example, "
-                "[('property1', IntegerProperty())]",
-            ),
-            e,
-        )
+        raise ValueError(
+            "properties must be dict-like, e.g. a list "
+            "containing tuples.  For example, "
+            "[('property1', IntegerProperty())]",
+        ) from e
 
 
 def _custom_object_builder(cls, type, properties, version, base_class):

--- a/stix2/datastore/__init__.py
+++ b/stix2/datastore/__init__.py
@@ -15,8 +15,6 @@ Python STIX2 DataStore API.
 from abc import ABCMeta, abstractmethod
 import uuid
 
-from six import with_metaclass
-
 from stix2.datastore.filters import Filter, FilterSet
 from stix2.utils import deduplicate
 
@@ -219,7 +217,7 @@ class DataStoreMixin(object):
             raise AttributeError(msg % self.__class__.__name__)
 
 
-class DataSink(with_metaclass(ABCMeta)):
+class DataSink(metaclass=ABCMeta):
     """An implementer will create a concrete subclass from
     this class for the specific DataSink.
 
@@ -245,7 +243,7 @@ class DataSink(with_metaclass(ABCMeta)):
         """
 
 
-class DataSource(with_metaclass(ABCMeta)):
+class DataSource(metaclass=ABCMeta):
     """An implementer will create a concrete subclass from
     this class for the specific DataSource.
 

--- a/stix2/datastore/filesystem.py
+++ b/stix2/datastore/filesystem.py
@@ -6,8 +6,6 @@ import os
 import re
 import stat
 
-import six
-
 from stix2 import v20, v21
 from stix2.base import _STIXBase
 from stix2.datastore import (
@@ -116,7 +114,7 @@ def _update_allow(allow_set, value):
 
     """
     adding_seq = hasattr(value, "__iter__") and \
-        not isinstance(value, six.string_types)
+        not isinstance(value, str)
 
     if allow_set is None:
         allow_set = set()

--- a/stix2/datastore/filters.py
+++ b/stix2/datastore/filters.py
@@ -3,8 +3,6 @@
 import collections
 from datetime import datetime
 
-import six
-
 import stix2.utils
 
 """Supported filter operations"""
@@ -12,8 +10,7 @@ FILTER_OPS = ['=', '!=', 'in', '>', '<', '>=', '<=', 'contains']
 
 """Supported filter value types"""
 FILTER_VALUE_TYPES = (
-    bool, dict, float, int, list, tuple, six.string_types,
-    datetime,
+    bool, dict, float, int, list, tuple, str, datetime,
 )
 
 
@@ -84,7 +81,7 @@ class Filter(collections.namedtuple('Filter', ['property', 'op', 'value'])):
         # If filtering on a timestamp property and the filter value is a string,
         # try to convert the filter value to a datetime instance.
         if isinstance(stix_obj_property, datetime) and \
-                isinstance(self.value, six.string_types):
+                isinstance(self.value, str):
             filter_value = stix2.utils.parse_into_datetime(self.value)
         else:
             filter_value = self.value

--- a/stix2/markings/utils.py
+++ b/stix2/markings/utils.py
@@ -2,8 +2,6 @@
 
 import collections
 
-import six
-
 from stix2 import exceptions, utils
 
 
@@ -129,7 +127,7 @@ def compress_markings(granular_markings):
             {'marking_ref': item, 'selectors': sorted(selectors)}
             if utils.is_marking(item) else
             {'lang': item, 'selectors': sorted(selectors)}
-            for item, selectors in six.iteritems(map_)
+            for item, selectors in map_.items()
         ]
 
     return compressed
@@ -230,7 +228,7 @@ def iterpath(obj, path=None):
     if path is None:
         path = []
 
-    for varname, varobj in iter(sorted(six.iteritems(obj))):
+    for varname, varobj in iter(sorted(obj.items())):
         path.append(varname)
         yield (path, varobj)
 

--- a/stix2/pattern_visitor.py
+++ b/stix2/pattern_visitor.py
@@ -3,7 +3,6 @@
 import importlib
 import inspect
 
-from six import text_type
 from stix2patterns.exceptions import ParseException
 from stix2patterns.grammars.STIXPatternParser import TerminalNode
 from stix2patterns.v20.grammars.STIXPatternParser import \
@@ -263,7 +262,7 @@ class STIXPatternVisitorForSTIX2():
                 property_path.append(
                     self.instantiate(
                         "ListObjectPathComponent",
-                        current.property_name if isinstance(current, BasicObjectPathComponent) else text_type(current),
+                        current.property_name if isinstance(current, BasicObjectPathComponent) else str(current),
                         next.value,
                     ),
                 )
@@ -286,7 +285,7 @@ class STIXPatternVisitorForSTIX2():
         if isinstance(first_component, TerminalNode):
             step = first_component.getText()
         else:
-            step = text_type(first_component)
+            step = str(first_component)
         # if step.endswith("_ref"):
         #     return stix2.ReferenceObjectPathComponent(step)
         # else:

--- a/stix2/patterns.py
+++ b/stix2/patterns.py
@@ -5,8 +5,6 @@ import binascii
 import datetime
 import re
 
-import six
-
 from .utils import parse_into_datetime
 
 
@@ -15,7 +13,7 @@ def escape_quotes_and_backslashes(s):
 
 
 def quote_if_needed(x):
-    if isinstance(x, six.string_types):
+    if isinstance(x, str):
         if x.find("-") != -1:
             if not x.startswith("'"):
                 return "'" + x + "'"

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -7,8 +7,6 @@ import inspect
 import re
 import uuid
 
-from six import string_types, text_type
-
 from .base import _STIXBase
 from .exceptions import (
     CustomContentError, DictionaryKeyError, MissingPropertiesError,
@@ -227,7 +225,7 @@ class ListProperty(Property):
         except TypeError:
             raise ValueError("must be an iterable.")
 
-        if isinstance(value, (_STIXBase, string_types)):
+        if isinstance(value, (_STIXBase, str)):
             value = [value]
 
         if isinstance(self.contained, Property):
@@ -268,8 +266,8 @@ class StringProperty(Property):
         super(StringProperty, self).__init__(**kwargs)
 
     def clean(self, value):
-        if not isinstance(value, string_types):
-            return text_type(value)
+        if not isinstance(value, str):
+            return str(value)
         return value
 
 

--- a/stix2/test/v20/test_datastore_filters.py
+++ b/stix2/test/v20/test_datastore_filters.py
@@ -128,18 +128,17 @@ def test_filter_value_type_check():
 
     with pytest.raises(TypeError) as excinfo:
         Filter('created', '=', object())
-    # On Python 2, the type of object() is `<type 'object'>` On Python 3, it's `<class 'object'>`.
-    assert any([s in str(excinfo.value) for s in ["<type 'object'>", "'<class 'object'>'"]])
+    assert "'<class 'object'>'" in str(excinfo.value)
     assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", complex(2, -1))
-    assert any([s in str(excinfo.value) for s in ["<type 'complex'>", "'<class 'complex'>'"]])
+    assert "'<class 'complex'>'" in str(excinfo.value)
     assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", set([16, 23]))
-    assert any([s in str(excinfo.value) for s in ["<type 'set'>", "'<class 'set'>'"]])
+    assert "'<class 'set'>'" in str(excinfo.value)
     assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
 

--- a/stix2/test/v20/test_datastore_taxii.py
+++ b/stix2/test/v20/test_datastore_taxii.py
@@ -3,7 +3,6 @@ import json
 from medallion.filters.basic_filter import BasicFilter
 import pytest
 from requests.models import Response
-import six
 from taxii2client.common import _filter_kwargs_to_query_params
 from taxii2client.v20 import Collection
 
@@ -27,7 +26,7 @@ class MockTAXIICollectionEndpoint(Collection):
 
     def add_objects(self, bundle):
         self._verify_can_write()
-        if isinstance(bundle, six.string_types):
+        if isinstance(bundle, str):
             bundle = json.loads(bundle)
         for object in bundle.get("objects", []):
             self.objects.append(object)

--- a/stix2/test/v21/test_datastore_filters.py
+++ b/stix2/test/v21/test_datastore_filters.py
@@ -146,18 +146,17 @@ def test_filter_value_type_check():
 
     with pytest.raises(TypeError) as excinfo:
         Filter('created', '=', object())
-    # On Python 2, the type of object() is `<type 'object'>` On Python 3, it's `<class 'object'>`.
-    assert any([s in str(excinfo.value) for s in ["<type 'object'>", "'<class 'object'>'"]])
+    assert "'<class 'object'>'" in str(excinfo.value)
     assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", complex(2, -1))
-    assert any([s in str(excinfo.value) for s in ["<type 'complex'>", "'<class 'complex'>'"]])
+    assert "'<class 'complex'>'" in str(excinfo.value)
     assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         Filter("type", "=", set([16, 23]))
-    assert any([s in str(excinfo.value) for s in ["<type 'set'>", "'<class 'set'>'"]])
+    assert "'<class 'set'>'" in str(excinfo.value)
     assert "is not supported. The type must be a Python immutable type or dictionary" in str(excinfo.value)
 
 

--- a/stix2/test/v21/test_datastore_taxii.py
+++ b/stix2/test/v21/test_datastore_taxii.py
@@ -3,7 +3,6 @@ import json
 from medallion.filters.basic_filter import BasicFilter
 import pytest
 from requests.models import Response
-import six
 from taxii2client.common import _filter_kwargs_to_query_params
 from taxii2client.v21 import Collection
 
@@ -27,7 +26,7 @@ class MockTAXIICollectionEndpoint(Collection):
 
     def add_objects(self, bundle):
         self._verify_can_write()
-        if isinstance(bundle, six.string_types):
+        if isinstance(bundle, str):
             bundle = json.loads(bundle)
         for object in bundle.get("objects", []):
             self.objects.append(object)

--- a/stix2/test/v21/test_deterministic_ids.py
+++ b/stix2/test/v21/test_deterministic_ids.py
@@ -3,7 +3,6 @@ import datetime
 import uuid
 
 import pytest
-import six
 
 import stix2.base
 import stix2.canonicalization.Canonicalize
@@ -31,12 +30,7 @@ def _make_uuid5(name):
     """
     Make a STIX 2.1+ compliant UUIDv5 from a "name".
     """
-    if six.PY3:
-        uuid_ = uuid.uuid5(SCO_DET_ID_NAMESPACE, name)
-    else:
-        uuid_ = uuid.uuid5(
-            SCO_DET_ID_NAMESPACE, name.encode("utf-8"),
-        )
+    uuid_ = uuid.uuid5(SCO_DET_ID_NAMESPACE, name)
 
     return uuid_
 

--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -7,7 +7,6 @@ import json
 import re
 
 import pytz
-import six
 
 import stix2.registry as mappings
 import stix2.version
@@ -70,7 +69,7 @@ def _to_enum(value, enum_type, enum_default=None):
     if not isinstance(value, enum_type):
         if value is None and enum_default is not None:
             value = enum_default
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             value = enum_type[value.upper()]
         else:
             raise TypeError(

--- a/stix2/v20/common.py
+++ b/stix2/v20/common.py
@@ -3,8 +3,6 @@
 from collections import OrderedDict
 import copy
 
-import six
-
 from ..custom import _custom_marking_builder
 from ..markings import _MarkingsMixin
 from ..markings.utils import check_tlp_marking
@@ -21,7 +19,7 @@ def _should_set_millisecond(cr, marking_type):
     if marking_type == TLPMarking:
         return True
     # otherwise,  precision is kept from how it was given
-    if isinstance(cr, six.string_types):
+    if isinstance(cr, str):
         if '.' in cr:
             return True
         else:

--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -2,9 +2,9 @@
 
 from collections import OrderedDict
 import itertools
+from urllib.parse import quote_plus
 import warnings
 
-from six.moves.urllib.parse import quote_plus
 from stix2patterns.validator import run_validator
 
 from ..custom import _custom_object_builder


### PR DESCRIPTION
We've already removed Python 2 from our test harness, but this removes all python 2 compatibility code that we left in.

Since we no longer need our Python 2 compatibility changes to the JSON canonicalization code, I reverted it to the version of the code at https://github.com/cyberphone/json-canonicalization/tree/master/python3. Since it follows a different code style than we do I excluded it from our pre-commit checks.