### PR TITLE
Fix sighting.last_seen check

### DIFF
--- a/stix2/v21/sdo.py
+++ b/stix2/v21/sdo.py
@@ -83,7 +83,7 @@ class Campaign(_DomainObject):
         last_seen = self.get('last_seen')
 
         if first_seen and last_seen and last_seen < first_seen:
-            msg = "{0.id} 'last_seen' must be greater than or equal 'first_seen'"
+            msg = "{0.id} 'last_seen' must be greater than or equal to 'first_seen'"
             raise ValueError(msg.format(self))
 
 

--- a/stix2/v21/sro.py
+++ b/stix2/v21/sro.py
@@ -111,6 +111,6 @@ class Sighting(_RelationshipObject):
         first_seen = self.get('first_seen')
         last_seen = self.get('last_seen')
 
-        if first_seen and last_seen and last_seen <= first_seen:
-            msg = "{0.id} 'last_seen' must be later than 'first_seen'"
+        if first_seen and last_seen and last_seen < first_seen:
+            msg = "{0.id} 'last_seen' must be greater than or equal to 'first_seen'"
             raise ValueError(msg.format(self))


### PR DESCRIPTION
It is allowed to be equal to first_seen, per https://github.com/oasis-tcs/cti-stix2/issues/247.