### PR TITLE
Fix the CustomExtension example in the custom.ipynb jupyter notebook.

### DIFF
--- a/docs/guide/custom.ipynb
+++ b/docs/guide/custom.ipynb
@@ -1577,9 +1577,9 @@
     }
    ],
    "source": [
-    "from stix2 import File, CustomExtension\n",
+    "from stix2 import CustomExtension\n",
     "\n",
-    "@CustomExtension(File, 'x-new-ext', [\n",
+    "@CustomExtension('x-new-ext', [\n",
     "    ('property1', properties.StringProperty(required=True)),\n",
     "    ('property2', properties.IntegerProperty()),\n",
     "])\n",
@@ -1803,7 +1803,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1817,7 +1817,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0a6"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes issue #518 .

These changes also include whatever other minor stuff came along with making a minimal change and saving the resulting notebook.