### PR TITLE
Fix detect_spec_version() with respect to 2.0 bundles

### DIFF
--- a/stix2/test/test_spec_version_detect.py
+++ b/stix2/test/test_spec_version_detect.py
@@ -77,6 +77,35 @@ from stix2.utils import detect_spec_version
             },
             "2.0",
         ),
+        (
+            {
+                "type": "bundle",
+                "id": "bundle--8379cb02-8131-47c8-8a7c-9a1f0e0986b1",
+                "spec_version": "2.1",
+                "objects": [
+                    {
+                        "type": "identity",
+                        "spec_version": "2.1",
+                        "id": "identity--d7f72e8d-657a-43ec-9324-b3ec67a97486",
+                        "created": "1972-05-21T05:33:09.000Z",
+                        "modified": "1973-05-28T02:10:54.000Z",
+                        "name": "alice",
+                        "identity_class": "individual",
+                    },
+                    {
+                        "type": "marking-definition",
+                        "spec_version": "2.1",
+                        "id": "marking-definition--2a13090f-a493-4b70-85fe-fa021d91dcd2",
+                        "created": "1998-03-27T19:44:53.000Z",
+                        "definition_type": "statement",
+                        "definition": {
+                            "statement": "Copyright (c) ACME Corp.",
+                        },
+                    },
+                ],
+            },
+            "2.0",
+        ),
         # STIX 2.1 examples
         (
             {

--- a/stix2/test/v20/test_utils.py
+++ b/stix2/test/v20/test_utils.py
@@ -349,6 +349,10 @@ def test_is_not_sro_dict(dict_):
         {"type": "identity"},
         {"type": "software"},
         {"type": "marking-definition"},
+        # Presence of spec_version property implies a STIX 2.0 bundle,
+        # regardless of the property's value.  STIX 2.1 bundles don't have a
+        # "spec_version" property defined.
+        {"type": "bundle", "spec_version": "2.1"},
         {
             "type": "bundle",
             "id": "bundle--8f431680-6278-4767-ba43-5edb682d7086",
@@ -370,12 +374,20 @@ def test_is_object_dict(dict_):
         {"type": "identity", "spec_version": "2.1"},
         {"type": "software", "spec_version": "2.1"},
         {"type": "marking-definition", "spec_version": "2.1"},
-        {"type": "bundle", "spec_version": "2.1"},
         {"type": "language-content", "spec_version": "2.1"},
         {"type": "relationship", "spec_version": "2.1"},
         {"type": "sighting", "spec_version": "2.1"},
         {"type": "foo", "spec_version": "2.1"},
         {"type": "foo"},
+        {
+            "type": "bundle",
+            "id": "bundle--8f431680-6278-4767-ba43-5edb682d7086",
+            "objects": [
+                {"type": "identity"},
+                {"type": "software"},
+                {"type": "marking-definition"},
+            ],
+        },
     ],
 )
 def test_is_not_object_dict(dict_):

--- a/stix2/test/v21/test_utils.py
+++ b/stix2/test/v21/test_utils.py
@@ -382,7 +382,7 @@ def test_is_object_dict(dict_):
         {"type": "identity"},
         {"type": "software"},
         {"type": "marking-definition"},
-        {"type": "bundle"},
+        {"type": "bundle", "spec_version": "2.1"},
         {"type": "language-content"},
         {"type": "relationship"},
         {"type": "sighting"},

--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -327,9 +327,15 @@ def detect_spec_version(stix_dict):
     obj_type = stix_dict["type"]
 
     if 'spec_version' in stix_dict:
-        # For STIX 2.0, applies to bundles only.
-        # For STIX 2.1+, applies to SCOs, SDOs, SROs, and markings only.
-        v = stix_dict['spec_version']
+        # For STIX 2.0, applies to bundles only.  Presence in a bundle implies
+        # STIX 2.0; the value applies to the content of the bundle, not the
+        # bundle itself, so we don't care here about the value.
+        #
+        # For STIX 2.1+, applies to non-bundles only.
+        if obj_type == "bundle":
+            v = "2.0"
+        else:
+            v = stix_dict['spec_version']
     elif "id" not in stix_dict:
         # Only 2.0 SCOs don't have ID properties
         v = "2.0"


### PR DESCRIPTION
Fixes #541 .

Fix detect_spec_version() such that it uses presence of the "spec_version" property in a bundle to infer spec version, not the property's value.  Update unit tests accordingly.

Content was discovered which consisted of a bundle with spec_version="2.1".  This is (perhaps confusingly) a STIX 2.0 bundle, but it was incorrectly being identified by the library as a STIX 2.1 bundle.  This produced the following error when parsing it:

    stix2.exceptions.ExtraPropertiesError: Unexpected properties for Bundle: (spec_version).

because STIX 2.1 bundles don't have a spec_version property.  The object's spec_version property was used to determine that it should not have a spec_version property.  Doesn't make much sense.  With this PR, you get:

    stix2.exceptions.InvalidValueError: Invalid value for Bundle 'spec_version': must equal '2.0'.

This is correct: the library defines the spec_version property of STIX 2.0 bundles to have a fixed value of "2.0", since content of other spec versions is not supported in a STIX 2.0 bundle by this library.  This shows the spec version of the bundle was properly detected.