### PR TITLE
Use string comparison in pattern semantic similarity calculations

### DIFF
--- a/stix2/equivalence/object/__init__.py
+++ b/stix2/equivalence/object/__init__.py
@@ -6,7 +6,7 @@ import time
 
 from ...datastore import DataSource, DataStoreMixin, Filter
 from ...utils import STIXdatetime, parse_into_datetime
-from ..pattern import equivalent_patterns
+from ..pattern import normalize_pattern
 
 logger = logging.getLogger(__name__)
 
@@ -307,7 +307,13 @@ def custom_pattern_based(pattern1, pattern2):
         float: Number between 0.0 and 1.0 depending on match criteria.
 
     """
-    return equivalent_patterns(pattern1, pattern2)
+    norm_patt1 = normalize_pattern(pattern1)
+    norm_patt2 = normalize_pattern(pattern2)
+
+    patt_str1 = str(norm_patt1)[1:-1]  # don't include brackets
+    patt_str2 = str(norm_patt2)[1:-1]
+
+    return partial_string_based(patt_str1, patt_str2)
 
 
 def partial_external_reference_based(ext_refs1, ext_refs2):

--- a/stix2/equivalence/pattern/__init__.py
+++ b/stix2/equivalence/pattern/__init__.py
@@ -57,6 +57,28 @@ def _get_pattern_normalizer():
     return _pattern_normalizer
 
 
+def normalize_pattern(pattern, stix_version=DEFAULT_VERSION):
+    """
+    Normalize a STIX pattern.
+
+    Args:
+        pattern: The STIX pattern to normalize
+        stix_version: The STIX version to use for pattern parsing, as a string
+            ("2.0", "2.1", etc).  Defaults to library-wide default version.
+
+    Returns:
+        The normalized form of the given STIX pattern
+    """
+    patt_ast = pattern_visitor.create_pattern_object(
+        pattern, version=stix_version,
+    )
+
+    pattern_normalizer = _get_pattern_normalizer()
+    norm_patt, _ = pattern_normalizer.transform(patt_ast)
+
+    return norm_patt
+
+
 def equivalent_patterns(pattern1, pattern2, stix_version=DEFAULT_VERSION):
     """
     Determine whether two STIX patterns are semantically equivalent.
@@ -70,16 +92,8 @@ def equivalent_patterns(pattern1, pattern2, stix_version=DEFAULT_VERSION):
     Returns:
         True if the patterns are semantically equivalent; False if not
     """
-    patt_ast1 = pattern_visitor.create_pattern_object(
-        pattern1, version=stix_version,
-    )
-    patt_ast2 = pattern_visitor.create_pattern_object(
-        pattern2, version=stix_version,
-    )
-
-    pattern_normalizer = _get_pattern_normalizer()
-    norm_patt1, _ = pattern_normalizer.transform(patt_ast1)
-    norm_patt2, _ = pattern_normalizer.transform(patt_ast2)
+    norm_patt1 = normalize_pattern(pattern1, stix_version)
+    norm_patt2 = normalize_pattern(pattern2, stix_version)
 
     result = observation_expression_cmp(norm_patt1, norm_patt2)
 

--- a/stix2/test/v21/test_environment.py
+++ b/stix2/test/v21/test_environment.py
@@ -743,9 +743,9 @@ def test_object_similarity_zero_match():
     ind1 = stix2.v21.Indicator(id=INDICATOR_ID, **INDICATOR_KWARGS)
     ind2 = stix2.v21.Indicator(id=INDICATOR_ID, **IND_KWARGS)
     env = stix2.Environment().object_similarity(ind1, ind2, **weights)
-    assert round(env) == 0
+    assert env < 50
     env = stix2.Environment().object_similarity(ind2, ind1, **weights)
-    assert round(env) == 0
+    assert env < 50
 
 
 def test_object_similarity_different_spec_version():
@@ -764,10 +764,10 @@ def test_object_similarity_different_spec_version():
     ind1 = stix2.v21.Indicator(id=INDICATOR_ID, **INDICATOR_KWARGS)
     ind2 = stix2.v20.Indicator(id=INDICATOR_ID, **IND_KWARGS)
     env = stix2.Environment().object_similarity(ind1, ind2, ignore_spec_version=True, **weights)
-    assert round(env) == 0
+    assert env < 50
 
     env = stix2.Environment().object_similarity(ind2, ind1, ignore_spec_version=True, **weights)
-    assert round(env) == 0
+    assert env < 50
 
 
 @pytest.mark.parametrize(
@@ -977,7 +977,7 @@ def test_semantic_check_with_versioning(ds, ds2):
     )
     ds.add(ind)
     score = stix2.equivalence.object.reference_check(ind.id, INDICATOR_ID, ds, ds2, **weights)
-    assert round(score) == 0  # Since pattern is different score is really low
+    assert score < 0.55  # Since pattern is different score is low
 
 
 def test_list_semantic_check(ds, ds2):


### PR DESCRIPTION
So it will return a % instead of a boolean, to be consistent with the other similarity functions.