### PR TITLE
fix: Ensure year is always 4 digits

### DIFF
--- a/stix2/utils.py
+++ b/stix2/utils.py
@@ -18,8 +18,8 @@ NOW = object()
 
 PREFIX_21_REGEX = re.compile(r'^[a-z].*')
 
-_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-_TIMESTAMP_FORMAT_FRAC = "%Y-%m-%dT%H:%M:%S.%fZ"
+_TIMESTAMP_FORMAT = "%4Y-%m-%dT%H:%M:%SZ"
+_TIMESTAMP_FORMAT_FRAC = "%4Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class Precision(enum.Enum):
@@ -167,7 +167,7 @@ def format_datetime(dttm):
         zoned = pytz.utc.localize(dttm)
     else:
         zoned = dttm.astimezone(pytz.utc)
-    ts = zoned.strftime('%Y-%m-%dT%H:%M:%S')
+    ts = zoned.strftime('%4Y-%m-%dT%H:%M:%S')
     precision = getattr(dttm, 'precision', Precision.ANY)
     precision_constraint = getattr(
         dttm, 'precision_constraint', PrecisionConstraint.EXACT,


### PR DESCRIPTION
Because of [this issue](https://github.com/python/cpython/issues/57514) in CPython on some platform the dates having a year smaller than 1000 will be on less than 4 digits.

```py
format_datetime(datetime(200, 1, 1)) # 200-01-01T00:00:00Z
```

This PR make sure that the year is always formatted with 4 digits:

```py
format_datetime(datetime(200, 1, 1)) # 0200-01-01T00:00:00Z
```