### PR TITLE
Adding TLP CLEAR

### DIFF
--- a/stix2/v21/common.py
+++ b/stix2/v21/common.py
@@ -281,6 +281,14 @@ TLP_WHITE = MarkingDefinition(
     definition=TLPMarking(tlp='white'),
 )
 
+TLP_CLEAR = MarkingDefinition(
+    id='marking-definition--94868c89-83c2-464b-929b-a1a8aa3c8487',
+    created='2022-10-01T00:00:00.000Z',
+    definition_type='tlp',
+    name='TLP:CLEAR',
+    definition=TLPMarking(tlp='clear'),
+)
+
 TLP_GREEN = MarkingDefinition(
     id='marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da',
     created='2017-01-20T00:00:00.000Z',


### PR DESCRIPTION
TLP:CLEAR was added as part of TLP 2.0. 

Extension definition:
https://github.com/oasis-open/cti-stix-common-objects/blob/main/objects/extension-definition/extension-definition--60a3c5c5-0d10-413e-aab3-9e08dde9e88d.json

TLP CLEAR marking definition:
https://github.com/oasis-open/cti-stix-common-objects/blob/main/objects/marking-definition/marking-definition--94868c89-83c2-464b-929b-a1a8aa3c8487.json

Resolves https://github.com/oasis-open/cti-python-stix2/issues/569