### PR TITLE
Support for UUID v5

### DIFF
--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -43,7 +43,7 @@ def _check_uuid(uuid_str, spec_version):
 
     ok = uuid_obj.variant == uuid.RFC_4122
     if ok and spec_version == "2.0":
-        ok = uuid_obj.version == 4
+        ok = uuid_obj.version == 4 or uuid_obj.version == 5
 
     return ok
 


### PR DESCRIPTION
Avoid {stix2.exceptions.InvalidValueError} when passing Indicators of Compromise (IoC) that includes UUID Version 5 in STIX2.0.