### PR TITLE
Dictionary Prop Adjustments

### DIFF
--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -226,7 +226,7 @@ class ListProperty(Property):
 
         super(ListProperty, self).__init__(**kwargs)
 
-    def clean(self, value, allow_custom):
+    def clean(self, value, allow_custom, strict_flag=False):
         try:
             iter(value)
         except TypeError:
@@ -240,7 +240,7 @@ class ListProperty(Property):
         if isinstance(self.contained, Property):
             for item in value:
                 try:
-                    valid, temp_custom = self.contained.clean(item, allow_custom, strict=True)
+                    valid, temp_custom = self.contained.clean(item, allow_custom, strict=strict_flag)
                 except TypeError:
                     valid, temp_custom = self.contained.clean(item, allow_custom)
                 result.append(valid)
@@ -451,7 +451,7 @@ class DictionaryProperty(Property):
             clean = False
             for type_ in self.valid_types:
                 if isinstance(type_, ListProperty):
-                    type_.clean(value=dictified[k], allow_custom=False)
+                    type_.clean(value=dictified[k], allow_custom=False, strict_flag=True)
                     clean = True
                 else:
                     type_instance = type_()

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -476,6 +476,7 @@ class DictionaryProperty(Property):
                 try:
                     type_instance.clean(dictified[k])
                     clean = True
+                    break
                 except ValueError:
                     continue
             

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -391,7 +391,7 @@ class DictionaryProperty(Property):
         self.spec_version = spec_version
 
         if not valid_types:
-            valid_types = StringProperty
+            valid_types = [StringProperty]
         # elif not isinstance(valid_types, ListProperty):
         #     valid_types = [valid_types]
         
@@ -444,18 +444,23 @@ class DictionaryProperty(Property):
             #         raise ValueError("The dictionary expects values of type str or int")
 
             simple_type = [BinaryProperty, BooleanProperty, FloatProperty, HashesProperty, HexProperty, IDProperty, IntegerProperty, StringProperty, TimestampProperty]
-
-            if self.valid_types in simple_type:
-                self.valid_types.clean(dict[k])
-            elif isinstance(dictified[k], ListProperty()):
-                list_type = dictified[k].contained
-                if list_type in simple_type:
-                    for x in dictified[k]:
-                        list_type.clean(x)
-                else:
-                    raise ValueError("Dictionary Property does not support lists of type: ", list_type)
-            else:
-                raise ValueError("Dictionary Property does not support this value's type: ", self.valid_types)
+            clear = False
+            for type in self.valid_types:
+                if type in simple_type:
+                    try:
+                        self.valid_types.clean(dict[k])
+                    except ValueError:
+                        continue
+                    clear = True
+                elif isinstance(dictified[k], ListProperty()):
+                    list_type = dictified[k].contained
+                    if list_type in simple_type:
+                        for x in dictified[k]:
+                            list_type.clean(x)
+                    else:
+                        raise ValueError("Dictionary Property does not support lists of type: ", list_type)
+                if not clear:
+                    raise ValueError("Dictionary Property does not support this value's type: ", self.valid_types)
 
         if len(dictified) < 1:
             raise ValueError("must not be empty.")

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -391,18 +391,18 @@ class DictionaryProperty(Property):
         self.spec_version = spec_version
 
         if not valid_types:
-            valid_types = ["string"]
-        elif not isinstance(valid_types, ListProperty):
-            valid_types = [valid_types]
+            valid_types = StringProperty
+        # elif not isinstance(valid_types, ListProperty):
+        #     valid_types = [valid_types]
         
-        if 'string_list' in valid_types and len(valid_types) > 1:
-            raise ValueError("'string_list' cannot be combined with other types in a list.")
+        # if 'string_list' in valid_types and len(valid_types) > 1:
+        #     raise ValueError("'string_list' cannot be combined with other types in a list.")
 
-        for type_ in valid_types:
-            if type_ not in ("string", "integer", "string_list"):
-                raise ValueError("The value of a dictionary key cannot be ", type_)
+        # for type_ in valid_types:
+        #     if type_ not in ("string", "integer", "string_list"):
+        #         raise ValueError("The value of a dictionary key cannot be ", type_)
 
-        self.specifics = valid_types
+        self.valid_types = valid_types
 
         super(DictionaryProperty, self).__init__(**kwargs)
 
@@ -430,18 +430,32 @@ class DictionaryProperty(Property):
                 )
                 raise DictionaryKeyError(k, msg)
             
-            if "string" in valid_types:
-                if not isinstance(dictified[k], StringProperty):
-                    raise ValueError("The dictionary expects values of type str")
-            elif "integer" in valid_types:
-                if not isinstance(dictified[k], IntegerProperty):
-                    raise ValueError("The dictionary expects values of type int")
-            elif "string_list" in valid_types:
-                if not isinstance(dictified[k], ListProperty(StringProperty)):
-                    raise ValueError("The dictionary expects values of type list[str]")
+            # if "string" in valid_types:
+            #     if not isinstance(dictified[k], StringProperty):
+            #         raise ValueError("The dictionary expects values of type str")
+            # elif "integer" in valid_types:
+            #     if not isinstance(dictified[k], IntegerProperty):
+            #         raise ValueError("The dictionary expects values of type int")
+            # elif "string_list" in valid_types:
+            #     if not isinstance(dictified[k], ListProperty(StringProperty)):
+            #         raise ValueError("The dictionary expects values of type list[str]")
+            # else:
+            #     if not isinstance(dictified[k], StringProperty) or not isinstance(dictified[k], IntegerProperty):
+            #         raise ValueError("The dictionary expects values of type str or int")
+
+            simple_type = [BinaryProperty, BooleanProperty, FloatProperty, HashesProperty, HexProperty, IDProperty, IntegerProperty, StringProperty, TimestampProperty]
+
+            if self.valid_types in simple_type:
+                self.valid_types.clean(dict[k])
+            elif isinstance(dictified[k], ListProperty()):
+                list_type = dictified[k].contained
+                if list_type in simple_type:
+                    for x in dictified[k]:
+                        list_type.clean(x)
+                else:
+                    raise ValueError("Dictionary Property does not support lists of type: ", list_type)
             else:
-                if not isinstance(dictified[k], StringProperty) or not isinstance(dictified[k], IntegerProperty):
-                    raise ValueError("The dictionary expects values of type str or int")
+                raise ValueError("Dictionary Property does not support this value's type: ", self.valid_types)
 
         if len(dictified) < 1:
             raise ValueError("must not be empty.")

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -133,7 +133,7 @@ class Property(object):
 
     Subclasses can also define the following functions:
 
-    - ``def clean(self, value, allow_custom) -> (any, has_custom):``
+    - ``def clean(self, value, allow_custom, strict) -> (any, has_custom):``
         - Return a value that is valid for this property, and enforce and
           detect value customization.  If ``value`` is not valid for this
           property, you may attempt to transform it first.  If ``value`` is not
@@ -148,7 +148,9 @@ class Property(object):
           mean there actually are any).  The method must return an appropriate
           value for has_custom.  Customization may not be applicable/possible
           for a property.  In that case, allow_custom can be ignored, and
-          has_custom must be returned as False.
+          has_custom must be returned as False. strict is a True/False flag 
+          that is used in the dictionary property. if strict is True, 
+          properties like StringProperty will be lenient in their clean method.
 
     - ``def default(self):``
         - provide a default value for this property.
@@ -191,7 +193,7 @@ class Property(object):
         if default:
             self.default = default
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
         return value, False
 
 
@@ -237,7 +239,10 @@ class ListProperty(Property):
         has_custom = False
         if isinstance(self.contained, Property):
             for item in value:
-                valid, temp_custom = self.contained.clean(item, allow_custom)
+                try:
+                    valid, temp_custom = self.contained.clean(item, allow_custom, strict=True)
+                except TypeError:
+                    valid, temp_custom = self.contained.clean(item, allow_custom)
                 result.append(valid)
                 has_custom = has_custom or temp_custom
 
@@ -275,8 +280,11 @@ class StringProperty(Property):
     def __init__(self, **kwargs):
         super(StringProperty, self).__init__(**kwargs)
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
         if not isinstance(value, str):
+            if strict is True:
+                raise ValueError("Must be a string.")
+
             value = str(value)
         return value, False
 
@@ -296,7 +304,7 @@ class IDProperty(Property):
         self.spec_version = spec_version
         super(IDProperty, self).__init__()
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
         _validate_id(value, self.spec_version, self.required_prefix)
         return value, False
 
@@ -311,7 +319,10 @@ class IntegerProperty(Property):
         self.max = max
         super(IntegerProperty, self).__init__(**kwargs)
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
+        if strict is True and not isinstance(value, int):
+            raise ValueError("must be an integer.")
+        
         try:
             value = int(value)
         except Exception:
@@ -335,7 +346,10 @@ class FloatProperty(Property):
         self.max = max
         super(FloatProperty, self).__init__(**kwargs)
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
+        if strict is True and not isinstance(value, float):
+            raise ValueError("must be a float.")
+        
         try:
             value = float(value)
         except Exception:
@@ -356,7 +370,7 @@ class BooleanProperty(Property):
     _trues = ['true', 't', '1', 1, True]
     _falses = ['false', 'f', '0', 0, False]
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
 
         if isinstance(value, str):
             value = value.lower()
@@ -379,7 +393,7 @@ class TimestampProperty(Property):
 
         super(TimestampProperty, self).__init__(**kwargs)
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
         return parse_into_datetime(
             value, self.precision, self.precision_constraint,
         ), False
@@ -390,26 +404,20 @@ class DictionaryProperty(Property):
     def __init__(self, valid_types=None, spec_version=DEFAULT_VERSION, **kwargs):
         self.spec_version = spec_version
 
-        simple_type = [BinaryProperty, BooleanProperty, FloatProperty, HashesProperty, HexProperty, IDProperty, IntegerProperty, StringProperty, TimestampProperty]
+        simple_types = [BinaryProperty, BooleanProperty, FloatProperty, HashesProperty, HexProperty, IDProperty, IntegerProperty, StringProperty, TimestampProperty]
         if not valid_types:
-            valid_types = [StringProperty]
+            valid_types = [Property]
         else:
             for type_ in valid_types:
                 if isinstance(type_, ListProperty):
-                    if type_.contained not in simple_type:
-                        raise ValueError("Dictionary Property does not support lists of type: ", type_.contained)
-                elif type_ not in simple_type:
+                    found = False
+                    for simple_type in simple_types:
+                        if isinstance(type_.contained, simple_type):
+                            found = True
+                    if not found:
+                        raise ValueError("Dictionary Property does not support lists of type: ", type_.contained, type(type_.contained))
+                elif type_ not in simple_types:
                     raise ValueError("Dictionary Property does not support this value's type: ", type_)
-
-        # elif not isinstance(valid_types, ListProperty):
-        #     valid_types = [valid_types]
-        
-        # if 'string_list' in valid_types and len(valid_types) > 1:
-        #     raise ValueError("'string_list' cannot be combined with other types in a list.")
-
-        # for type_ in valid_types:
-        #     if type_ not in ("string", "integer", "string_list"):
-        #         raise ValueError("The value of a dictionary key cannot be ", type_)
 
         self.valid_types = valid_types
 
@@ -420,7 +428,7 @@ class DictionaryProperty(Property):
             dictified = _get_dict(value)
         except ValueError:
             raise ValueError("The dictionary property must contain a dictionary")
-        
+
         for k in dictified.keys():
             if self.spec_version == '2.0':
                 if len(k) < 3:
@@ -437,51 +445,22 @@ class DictionaryProperty(Property):
                     "underscore (_)"
                 )
                 raise DictionaryKeyError(k, msg)
-            
-            # if "string" in valid_types:
-            #     if not isinstance(dictified[k], StringProperty):
-            #         raise ValueError("The dictionary expects values of type str")
-            # elif "integer" in valid_types:
-            #     if not isinstance(dictified[k], IntegerProperty):
-            #         raise ValueError("The dictionary expects values of type int")
-            # elif "string_list" in valid_types:
-            #     if not isinstance(dictified[k], ListProperty(StringProperty)):
-            #         raise ValueError("The dictionary expects values of type list[str]")
-            # else:
-            #     if not isinstance(dictified[k], StringProperty) or not isinstance(dictified[k], IntegerProperty):
-            #         raise ValueError("The dictionary expects values of type str or int")
 
-            # simple_type = [BinaryProperty, BooleanProperty, FloatProperty, HashesProperty, HexProperty, IDProperty, IntegerProperty, StringProperty, TimestampProperty]
-            # clear = False
-            # for type in self.valid_types:
-            #     if type in simple_type:
-            #         try:
-            #             self.valid_types.clean(dict[k])
-            #         except ValueError:
-            #             continue
-            #         clear = True
-            #     elif isinstance(dictified[k], ListProperty()):
-            #         list_type = dictified[k].contained
-            #         if list_type in simple_type:
-            #             for x in dictified[k]:
-            #                 list_type.clean(x)
-            #         else:
-            #             raise ValueError("Dictionary Property does not support lists of type: ", list_type)
-            #     if not clear:
-            #         raise ValueError("Dictionary Property does not support this value's type: ", self.valid_types)
-            
             clean = False
-            for type in self.valid_types:
-                type_instance = type()
-                try:
-                    type_instance.clean(dictified[k])
+            for type_ in self.valid_types:
+                if isinstance(type_, ListProperty):
+                    type_.clean(value=dictified[k], allow_custom=False)
                     clean = True
-                    break
-                except ValueError:
-                    continue
-            
+                else:
+                    type_instance = type_()
+                    try:
+                        type_instance.clean(value=dictified[k], allow_custom=False, strict=True)
+                        clean = True
+                        break
+                    except ValueError:
+                        continue
             if not clean:
-                raise ValueError("Dictionary Property does not support this value's type: ", self.valid_types)
+                raise ValueError("Dictionary Property does not support this value's type: ", type(dictified[k]))
 
         if len(dictified) < 1:
             raise ValueError("must not be empty.")
@@ -504,7 +483,7 @@ class HashesProperty(DictionaryProperty):
             if alg:
                 self.__alg_to_spec_name[alg] = spec_hash_name
 
-    def clean(self, value, allow_custom):
+    def clean(self, value, allow_custom, strict=False):
         # ignore the has_custom return value here; there is no customization
         # of DictionaryProperties.
         clean_dict, _ = super().clean(value, allow_custom)
@@ -552,7 +531,7 @@ class HashesProperty(DictionaryProperty):
 
 class BinaryProperty(Property):
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
         try:
             base64.b64decode(value)
         except (binascii.Error, TypeError):
@@ -562,7 +541,7 @@ class BinaryProperty(Property):
 
 class HexProperty(Property):
 
-    def clean(self, value, allow_custom=False):
+    def clean(self, value, allow_custom=False, strict=False):
         if not re.match(r"^([a-fA-F0-9]{2})+$", value):
             raise ValueError("must contain an even number of hexadecimal characters")
         return value, False

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -148,8 +148,8 @@ class Property(object):
           mean there actually are any).  The method must return an appropriate
           value for has_custom.  Customization may not be applicable/possible
           for a property.  In that case, allow_custom can be ignored, and
-          has_custom must be returned as False. strict is a True/False flag 
-          that is used in the dictionary property. if strict is True, 
+          has_custom must be returned as False. strict is a True/False flag
+          that is used in the dictionary property. if strict is True,
           properties like StringProperty will be lenient in their clean method.
 
     - ``def default(self):``
@@ -322,7 +322,7 @@ class IntegerProperty(Property):
     def clean(self, value, allow_custom=False, strict=False):
         if strict is True and not isinstance(value, int):
             raise ValueError("must be an integer.")
-        
+
         try:
             value = int(value)
         except Exception:
@@ -349,7 +349,7 @@ class FloatProperty(Property):
     def clean(self, value, allow_custom=False, strict=False):
         if strict is True and not isinstance(value, float):
             raise ValueError("must be a float.")
-        
+
         try:
             value = float(value)
         except Exception:

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -404,10 +404,12 @@ class DictionaryProperty(Property):
     def __init__(self, valid_types=None, spec_version=DEFAULT_VERSION, **kwargs):
         self.spec_version = spec_version
 
-        simple_types = [BinaryProperty, BooleanProperty, FloatProperty, HashesProperty, HexProperty, IDProperty, IntegerProperty, StringProperty, TimestampProperty]
+        simple_types = [BinaryProperty, BooleanProperty, FloatProperty, HexProperty, IntegerProperty, StringProperty, TimestampProperty, ReferenceProperty]
         if not valid_types:
             valid_types = [Property]
         else:
+            if not isinstance(valid_types, list):
+                valid_types = [valid_types]
             for type_ in valid_types:
                 if isinstance(type_, ListProperty):
                     found = False

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -392,10 +392,11 @@ class DictionaryProperty(Property):
 
         if not valid_types:
             valid_types = ["string"]
-        elif not isinstance(valid_types, list):
+        elif not isinstance(valid_types, ListProperty):
             valid_types = [valid_types]
-        elif isinstance(valid_types, list) and 'string_list' in valid_types:
-            raise ValueError("The value of a dictionary key cannot be [\"string_list\"]")
+        
+        if 'string_list' in valid_types and len(valid_types) > 1:
+            raise ValueError("'string_list' cannot be combined with other types in a list.")
 
         for type_ in valid_types:
             if type_ not in ("string", "integer", "string_list"):
@@ -429,24 +430,18 @@ class DictionaryProperty(Property):
                 )
                 raise DictionaryKeyError(k, msg)
             
-            if valid_types == "string":
-                if not isinstance(dictified[k], str):
+            if "string" in valid_types:
+                if not isinstance(dictified[k], StringProperty):
                     raise ValueError("The dictionary expects values of type str")
-            elif valid_types == "integer":
-                if not isinstance(dictified[k], int):
+            elif "integer" in valid_types:
+                if not isinstance(dictified[k], IntegerProperty):
                     raise ValueError("The dictionary expects values of type int")
-            elif valid_types == "string_list":
-                if not isinstance(dictified[k], list):
+            elif "string_list" in valid_types:
+                if not isinstance(dictified[k], ListProperty(StringProperty)):
                     raise ValueError("The dictionary expects values of type list[str]")
-                for x in dictified[k]:
-                    if not isinstance(x, str):
-                        raise ValueError("The dictionary expects values of type list[str]")
             else:
-                if not isinstance(dictified[k], list):
-                    raise ValueError("The dictionary expects values of type list[str/int]")
-                for x in dictified[k]:
-                    if not isinstance(x, str) or not isinstance(x, int):
-                        raise ValueError("The dictionary expects values of type list[str/int]")
+                if not isinstance(dictified[k], StringProperty) or not isinstance(dictified[k], IntegerProperty):
+                    raise ValueError("The dictionary expects values of type str or int")
 
         if len(dictified) < 1:
             raise ValueError("must not be empty.")

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -150,7 +150,7 @@ class Property(object):
           for a property.  In that case, allow_custom can be ignored, and
           has_custom must be returned as False. strict is a True/False flag
           that is used in the dictionary property. if strict is True,
-          properties like StringProperty will be lenient in their clean method.
+          properties like StringProperty will not be lenient in their clean method.
 
     - ``def default(self):``
         - provide a default value for this property.

--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -394,6 +394,8 @@ class DictionaryProperty(Property):
             valid_types = ["string"]
         elif not isinstance(valid_types, list):
             valid_types = [valid_types]
+        elif isinstance(valid_types, list) and 'string_list' in valid_types:
+            raise ValueError("The value of a dictionary key cannot be [\"string_list\"]")
 
         for type_ in valid_types:
             if type_ not in ("string", "integer", "string_list"):
@@ -408,6 +410,8 @@ class DictionaryProperty(Property):
             dictified = _get_dict(value)
         except ValueError:
             raise ValueError("The dictionary property must contain a dictionary")
+        
+        valid_types = self.specifics
         for k in dictified.keys():
             if self.spec_version == '2.0':
                 if len(k) < 3:
@@ -424,6 +428,25 @@ class DictionaryProperty(Property):
                     "underscore (_)"
                 )
                 raise DictionaryKeyError(k, msg)
+            
+            if valid_types == "string":
+                if not isinstance(dictified[k], str):
+                    raise ValueError("The dictionary expects values of type str")
+            elif valid_types == "integer":
+                if not isinstance(dictified[k], int):
+                    raise ValueError("The dictionary expects values of type int")
+            elif valid_types == "string_list":
+                if not isinstance(dictified[k], list):
+                    raise ValueError("The dictionary expects values of type list[str]")
+                for x in dictified[k]:
+                    if not isinstance(x, str):
+                        raise ValueError("The dictionary expects values of type list[str]")
+            else:
+                if not isinstance(dictified[k], list):
+                    raise ValueError("The dictionary expects values of type list[str/int]")
+                for x in dictified[k]:
+                    if not isinstance(x, str) or not isinstance(x, int):
+                        raise ValueError("The dictionary expects values of type list[str/int]")
 
         if len(dictified) < 1:
             raise ValueError("must not be empty.")

--- a/stix2/test/v21/test_observed_data.py
+++ b/stix2/test/v21/test_observed_data.py
@@ -1176,14 +1176,14 @@ def test_incorrect_socket_options():
         )
     assert "Incorrect options key" == str(excinfo.value)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(Exception) as excinfo:
         stix2.v21.SocketExt(
             is_listening=True,
             address_family="AF_INET",
             socket_type="SOCK_STREAM",
             options={"SO_RCVTIMEO": '100'},
         )
-    assert "Options value must be an integer" == str(excinfo.value)
+    assert "Dictionary Property does not support this value's type" in str(excinfo.value)
 
 
 def test_network_traffic_tcp_example():

--- a/stix2/test/v21/test_properties.py
+++ b/stix2/test/v21/test_properties.py
@@ -39,20 +39,27 @@ def test_dictionary_property_values_int():
         assert q.clean()
 
 def test_dictionary_property_values_stringlist():
-    p = DictionaryProperty(valid_types="string_list", spec_version='2.1', value={'x': ['123', '456']})
+    p = DictionaryProperty(valid_types="string_list", spec_version='2.1', value={'x': ['abc', 'def']})
     assert p.clean()
 
     q = DictionaryProperty(valid_types="string_list", spec_version='2.1', value={'x': '123'})
     with pytest.raises(ValueError):
         assert q.clean()
 
+    r = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': [123, 456]})
+    with pytest.raises(ValueError):
+        assert r.clean()
+
 def test_dictionary_property_values_list():
-    p = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': ['123', '456']})
+    p = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': 123})
     assert p.clean()
 
     q = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': '123'})
+    assert q.clean()
+
+    r = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': ['abc', 'def']})
     with pytest.raises(ValueError):
-        assert q.clean()
+        assert r.clean()
 
 ID_PROP = IDProperty('my-type', spec_version="2.1")
 MY_ID = 'my-type--232c9d3f-49fc-4440-bb01-607f638778e7'

--- a/stix2/test/v21/test_properties.py
+++ b/stix2/test/v21/test_properties.py
@@ -22,6 +22,37 @@ def test_dictionary_property():
     with pytest.raises(ValueError):
         p.clean({})
 
+def test_dictionary_property_values_str():
+    p = DictionaryProperty(valid_types="string", spec_version='2.1', value={'x': '123'})
+    assert p.clean()
+
+    q = DictionaryProperty(valid_types="string", spec_version='2.1', value={'x': 123})
+    with pytest.raises(ValueError):
+        assert q.clean()
+
+def test_dictionary_property_values_int():
+    p = DictionaryProperty(valid_types="integer", spec_version='2.1', value={'x': 123})
+    assert p.clean()
+
+    q = DictionaryProperty(valid_types="integer", spec_version='2.1', value={'x': '123'})
+    with pytest.raises(ValueError):
+        assert q.clean()
+
+def test_dictionary_property_values_stringlist():
+    p = DictionaryProperty(valid_types="string_list", spec_version='2.1', value={'x': ['123', '456']})
+    assert p.clean()
+
+    q = DictionaryProperty(valid_types="string_list", spec_version='2.1', value={'x': '123'})
+    with pytest.raises(ValueError):
+        assert q.clean()
+
+def test_dictionary_property_values_list():
+    p = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': ['123', '456']})
+    assert p.clean()
+
+    q = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': '123'})
+    with pytest.raises(ValueError):
+        assert q.clean()
 
 ID_PROP = IDProperty('my-type', spec_version="2.1")
 MY_ID = 'my-type--232c9d3f-49fc-4440-bb01-607f638778e7'

--- a/stix2/test/v21/test_properties.py
+++ b/stix2/test/v21/test_properties.py
@@ -7,8 +7,8 @@ from stix2.exceptions import (
 )
 from stix2.properties import (
     DictionaryProperty, EmbeddedObjectProperty, ExtensionsProperty,
-    HashesProperty, IDProperty, ListProperty, ObservableProperty,
-    ReferenceProperty, STIXObjectProperty, StringProperty, IntegerProperty
+    HashesProperty, IDProperty, IntegerProperty, ListProperty,
+    ObservableProperty, ReferenceProperty, STIXObjectProperty, StringProperty,
 )
 from stix2.v21.common import MarkingProperty
 
@@ -20,7 +20,7 @@ def test_dictionary_property():
 
     assert p.clean({'spec_version': '2.1'})
     with pytest.raises(ValueError):
-        p.clean({})
+        p.clean({}, False)
 
 def test_dictionary_property_values_str():
     p = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1')
@@ -29,7 +29,7 @@ def test_dictionary_property_values_str():
 
     q = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert q.clean({'x': 123})
+        assert q.clean({'x': [123]}, False)
 
 def test_dictionary_property_values_int():
     p = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1')
@@ -38,7 +38,7 @@ def test_dictionary_property_values_int():
 
     q = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert q.clean({'x': '123'})
+        assert q.clean({'x': [123]}, False)
 
 def test_dictionary_property_values_stringlist():
     p = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1')
@@ -47,7 +47,7 @@ def test_dictionary_property_values_stringlist():
 
     q = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert q.clean({'x': '123'})
+        assert q.clean({'x': [123]})
 
     r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')
     with pytest.raises(ValueError):
@@ -64,7 +64,7 @@ def test_dictionary_property_values_list():
 
     r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert r.clean({'x': ['abc', 'def']})
+        assert r.clean({'x': ['abc', 'def']}, False)
 
 ID_PROP = IDProperty('my-type', spec_version="2.1")
 MY_ID = 'my-type--232c9d3f-49fc-4440-bb01-607f638778e7'

--- a/stix2/test/v21/test_properties.py
+++ b/stix2/test/v21/test_properties.py
@@ -8,7 +8,7 @@ from stix2.exceptions import (
 from stix2.properties import (
     DictionaryProperty, EmbeddedObjectProperty, ExtensionsProperty,
     HashesProperty, IDProperty, ListProperty, ObservableProperty,
-    ReferenceProperty, STIXObjectProperty,
+    ReferenceProperty, STIXObjectProperty, StringProperty, IntegerProperty
 )
 from stix2.v21.common import MarkingProperty
 
@@ -23,41 +23,41 @@ def test_dictionary_property():
         p.clean({})
 
 def test_dictionary_property_values_str():
-    p = DictionaryProperty(valid_types="string", spec_version='2.1', value={'x': '123'})
+    p = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1', value={'x': '123'})
     assert p.clean()
 
-    q = DictionaryProperty(valid_types="string", spec_version='2.1', value={'x': 123})
+    q = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1', value={'x': 123})
     with pytest.raises(ValueError):
         assert q.clean()
 
 def test_dictionary_property_values_int():
-    p = DictionaryProperty(valid_types="integer", spec_version='2.1', value={'x': 123})
+    p = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1', value={'x': 123})
     assert p.clean()
 
-    q = DictionaryProperty(valid_types="integer", spec_version='2.1', value={'x': '123'})
+    q = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1', value={'x': '123'})
     with pytest.raises(ValueError):
         assert q.clean()
 
 def test_dictionary_property_values_stringlist():
-    p = DictionaryProperty(valid_types="string_list", spec_version='2.1', value={'x': ['abc', 'def']})
+    p = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1', value={'x': ['abc', 'def']})
     assert p.clean()
 
-    q = DictionaryProperty(valid_types="string_list", spec_version='2.1', value={'x': '123'})
+    q = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1', value={'x': '123'})
     with pytest.raises(ValueError):
         assert q.clean()
 
-    r = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': [123, 456]})
+    r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': [123, 456]})
     with pytest.raises(ValueError):
         assert r.clean()
 
 def test_dictionary_property_values_list():
-    p = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': 123})
+    p = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': 123})
     assert p.clean()
 
-    q = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': '123'})
+    q = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': '123'})
     assert q.clean()
 
-    r = DictionaryProperty(valid_types=['string', 'integer'], spec_version='2.1', value={'x': ['abc', 'def']})
+    r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': ['abc', 'def']})
     with pytest.raises(ValueError):
         assert r.clean()
 

--- a/stix2/test/v21/test_properties.py
+++ b/stix2/test/v21/test_properties.py
@@ -23,43 +23,48 @@ def test_dictionary_property():
         p.clean({})
 
 def test_dictionary_property_values_str():
-    p = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1', value={'x': '123'})
-    assert p.clean()
+    p = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1')
+    result = p.clean({'x': '123'}, False)
+    assert result == ({'x': '123'}, False)
 
-    q = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1', value={'x': 123})
+    q = DictionaryProperty(valid_types=[StringProperty], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert q.clean()
+        assert q.clean({'x': 123})
 
 def test_dictionary_property_values_int():
-    p = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1', value={'x': 123})
-    assert p.clean()
+    p = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1')
+    result = p.clean({'x': 123}, False)
+    assert result == ({'x': 123}, False)
 
-    q = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1', value={'x': '123'})
+    q = DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert q.clean()
+        assert q.clean({'x': '123'})
 
 def test_dictionary_property_values_stringlist():
-    p = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1', value={'x': ['abc', 'def']})
-    assert p.clean()
+    p = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1')
+    result = p.clean({'x': ['abc', 'def']}, False)
+    assert result == ({'x': ['abc', 'def']}, False)
 
-    q = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1', value={'x': '123'})
+    q = DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert q.clean()
+        assert q.clean({'x': '123'})
 
-    r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': [123, 456]})
+    r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert r.clean()
+        assert r.clean({'x': [123, 456]})
 
 def test_dictionary_property_values_list():
-    p = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': 123})
-    assert p.clean()
+    p = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')
+    result = p.clean({'x': 123}, False)
+    assert result == ({'x': 123}, False)
 
-    q = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': '123'})
-    assert q.clean()
+    q = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')
+    result = q.clean({'x': '123'}, False)
+    assert result == ({'x': '123'}, False)
 
-    r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1', value={'x': ['abc', 'def']})
+    r = DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')
     with pytest.raises(ValueError):
-        assert r.clean()
+        assert r.clean({'x': ['abc', 'def']})
 
 ID_PROP = IDProperty('my-type', spec_version="2.1")
 MY_ID = 'my-type--232c9d3f-49fc-4440-bb01-607f638778e7'

--- a/stix2/v21/observables.py
+++ b/stix2/v21/observables.py
@@ -181,7 +181,7 @@ class EmailMessage(_Observable):
         ('message_id', StringProperty()),
         ('subject', StringProperty()),
         ('received_lines', ListProperty(StringProperty)),
-        ('additional_header_fields', DictionaryProperty(valid_types="string_list", spec_version='2.1')),
+        ('additional_header_fields', DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1')),
         ('body', StringProperty()),
         ('body_multipart', ListProperty(EmbeddedObjectProperty(type=EmailMIMEComponent))),
         ('raw_email_ref', ReferenceProperty(valid_types='artifact', spec_version='2.1')),
@@ -245,7 +245,7 @@ class PDFExt(_Extension):
     _properties = OrderedDict([
         ('version', StringProperty()),
         ('is_optimized', BooleanProperty()),
-        ('document_info_dict', DictionaryProperty(valid_types="string", spec_version='2.1')),
+        ('document_info_dict', DictionaryProperty(valid_types=[StringProperty], spec_version='2.1')),
         ('pdfid0', StringProperty()),
         ('pdfid1', StringProperty()),
     ])
@@ -261,7 +261,7 @@ class RasterImageExt(_Extension):
         ('image_height', IntegerProperty()),
         ('image_width', IntegerProperty()),
         ('bits_per_pixel', IntegerProperty()),
-        ('exif_tags', DictionaryProperty(valid_types=["string", "integer"], spec_version='2.1')),
+        ('exif_tags', DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')),
     ])
 
 
@@ -468,7 +468,7 @@ class HTTPRequestExt(_Extension):
         ('request_method', StringProperty(required=True)),
         ('request_value', StringProperty(required=True)),
         ('request_version', StringProperty()),
-        ('request_header', DictionaryProperty(valid_types="string_list", spec_version='2.1')),
+        ('request_header', DictionaryProperty(valid_types=[ListProperty(StringProperty)], spec_version='2.1')),
         ('message_body_length', IntegerProperty()),
         ('message_body_data_ref', ReferenceProperty(valid_types='artifact', spec_version='2.1')),
     ])
@@ -496,7 +496,7 @@ class SocketExt(_Extension):
         ('address_family', EnumProperty(NETWORK_SOCKET_ADDRESS_FAMILY, required=True)),
         ('is_blocking', BooleanProperty()),
         ('is_listening', BooleanProperty()),
-        ('options', DictionaryProperty(valid_types="integer", spec_version='2.1')),
+        ('options', DictionaryProperty(valid_types=[IntegerProperty], spec_version='2.1')),
         ('socket_type', EnumProperty(NETWORK_SOCKET_TYPE)),
         ('socket_descriptor', IntegerProperty(min=0)),
         ('socket_handle', IntegerProperty()),
@@ -550,7 +550,7 @@ class NetworkTraffic(_Observable):
         ('dst_byte_count', IntegerProperty(min=0)),
         ('src_packets', IntegerProperty(min=0)),
         ('dst_packets', IntegerProperty(min=0)),
-        ('ipfix', DictionaryProperty(valid_types=["string", "integer"], spec_version='2.1')),
+        ('ipfix', DictionaryProperty(valid_types=[StringProperty, IntegerProperty], spec_version='2.1')),
         ('src_payload_ref', ReferenceProperty(valid_types='artifact', spec_version='2.1')),
         ('dst_payload_ref', ReferenceProperty(valid_types='artifact', spec_version='2.1')),
         ('encapsulates_refs', ListProperty(ReferenceProperty(valid_types='network-traffic', spec_version='2.1'))),
@@ -634,7 +634,7 @@ class Process(_Observable):
         ('created_time', TimestampProperty()),
         ('cwd', StringProperty()),
         ('command_line', StringProperty()),
-        ('environment_variables', DictionaryProperty(valid_types="string", spec_version='2.1')),
+        ('environment_variables', DictionaryProperty(valid_types=[StringProperty], spec_version='2.1')),
         ('opened_connection_refs', ListProperty(ReferenceProperty(valid_types='network-traffic', spec_version='2.1'))),
         ('creator_user_ref', ReferenceProperty(valid_types='user-account', spec_version='2.1')),
         ('image_ref', ReferenceProperty(valid_types='file', spec_version='2.1')),


### PR DESCRIPTION
Address #588 


- don't allow 'string_list' as one of the values when a list is given for valid_types
- in clean, check that the value of the dictionary items is the correct type as noted in specifics.
- some Tests to check for both the correct use of the DictionaryProperty definitions and instantiations