### PR TITLE
Add a starter relational DB source implementation

### DIFF
--- a/stix2/datastore/relational_db/relational_db_testing.py
+++ b/stix2/datastore/relational_db/relational_db_testing.py
@@ -4,7 +4,7 @@ import pytz
 
 import stix2
 from stix2.datastore.relational_db.relational_db import (
-    RelationalDBSink, RelationalDBSource,
+    RelationalDBSink, RelationalDBSource, RelationalDBStore
 )
 import stix2.properties
 
@@ -98,23 +98,18 @@ def file_example_with_PDFExt_Object():
 
 
 def main():
-    store = RelationalDBSink(
+    store = RelationalDBStore(
         "postgresql://localhost/stix-data-sink",
         False,
         None,
         True,
         stix2.Directory
     )
-    # store.generate_stix_schema()
+    store.sink.generate_stix_schema()
+
     store.add(directory_stix_object)
 
-    source = RelationalDBSource(
-        "postgresql://localhost/stix-data-sink",
-        stix2.Directory
-    )
-    source.generate_stix_schema()
-
-    read_obj = source.get(directory_stix_object.id)
+    read_obj = store.get(directory_stix_object.id)
     print(read_obj)
 
 

--- a/stix2/datastore/relational_db/relational_db_testing.py
+++ b/stix2/datastore/relational_db/relational_db_testing.py
@@ -3,7 +3,10 @@ import datetime as dt
 import pytz
 
 import stix2
-from stix2.datastore.relational_db.relational_db import RelationalDBSink
+from stix2.datastore.relational_db.relational_db import (
+    RelationalDBSink, RelationalDBSource,
+)
+import stix2.properties
 
 directory_stix_object = stix2.Directory(
     path="/foo/bar/a",
@@ -21,6 +24,7 @@ directory_stix_object = stix2.Directory(
 )
 
 s = stix2.v21.Software(
+        id="software--28897173-7314-4eec-b1cf-2c625b635bf6",
         name="Word",
         cpe="cpe:2.3:a:microsoft:word:2000:*:*:*:*:*:*:*",
         swid="com.acme.rms-ce-v4-1-5-0",
@@ -94,8 +98,24 @@ def file_example_with_PDFExt_Object():
 
 
 def main():
-    store = RelationalDBSink("postgresql://localhost/stix-data-sink")
-    store.generate_stix_schema()
+    store = RelationalDBSink(
+        "postgresql://localhost/stix-data-sink",
+        False,
+        None,
+        True,
+        stix2.Directory
+    )
+    # store.generate_stix_schema()
+    store.add(directory_stix_object)
+
+    source = RelationalDBSource(
+        "postgresql://localhost/stix-data-sink",
+        stix2.Directory
+    )
+    source.generate_stix_schema()
+
+    read_obj = source.get(directory_stix_object.id)
+    print(read_obj)
 
 
 if __name__ == '__main__':

--- a/stix2/datastore/relational_db/utils.py
+++ b/stix2/datastore/relational_db/utils.py
@@ -1,4 +1,9 @@
+from collections.abc import Iterable, Mapping
 import inflection
+from stix2.v21.base import (
+    _DomainObject, _Extension, _MetaObject, _Observable, _RelationshipObject,
+)
+
 
 # Helps us know which data goes in core, and which in a type-specific table.
 SCO_COMMON_PROPERTIES = {
@@ -36,3 +41,72 @@ def canonicalize_table_name(table_name, schema_name=None):
         full_name = table_name
     full_name = full_name.replace("-", "_")
     return inflection.underscore(full_name)
+
+
+def _get_all_subclasses(cls):
+    all_subclasses = []
+
+    for subclass in cls.__subclasses__():
+        all_subclasses.append(subclass)
+        all_subclasses.extend(_get_all_subclasses(subclass))
+    return all_subclasses
+
+
+def get_stix_object_classes():
+    yield from _get_all_subclasses(_DomainObject)
+    yield from _get_all_subclasses(_RelationshipObject)
+    yield from _get_all_subclasses(_Observable)
+    yield from _get_all_subclasses(_MetaObject)
+    # Non-object extensions (property or toplevel-property only)
+    for ext_cls in _get_all_subclasses(_Extension):
+        if ext_cls.extension_type in (
+            "property-extension", "toplevel-property-extension"
+        ):
+            yield ext_cls
+
+
+def schema_for(stix_class):
+
+    if issubclass(stix_class, _DomainObject):
+        schema_name = "sdo"
+    elif issubclass(stix_class, _RelationshipObject):
+        schema_name = "sro"
+    elif issubclass(stix_class, _Observable):
+        schema_name = "sco"
+    elif issubclass(stix_class, _MetaObject):
+        schema_name = "common"
+    elif issubclass(stix_class, _Extension):
+        schema_name = getattr(stix_class, "_applies_to", "sco")
+    else:
+        schema_name = None
+
+    return schema_name
+
+
+def table_name_for(stix_type_or_class):
+    if isinstance(stix_type_or_class, str):
+        table_name = stix_type_or_class
+    else:
+        # A _STIXBase subclass
+        table_name = getattr(stix_type_or_class, "_type", stix_type_or_class.__name__)
+
+    # Applies to registered extension-definition style extensions only.
+    # Their "_type" attribute is actually set to the extension definition ID,
+    # rather than a STIX type.
+    if table_name.startswith("extension-definition"):
+        table_name = table_name[0:30]
+
+    table_name = canonicalize_table_name(table_name)
+    return table_name
+
+
+def flat_classes(class_or_classes):
+    if isinstance(class_or_classes, Iterable) and not isinstance(
+        # Try to generically detect STIX objects, which are iterable, but we
+        # don't want to iterate through those.
+        class_or_classes, Mapping
+    ):
+        for class_ in class_or_classes:
+            yield from flat_classes(class_)
+    else:
+        yield class_or_classes


### PR DESCRIPTION
This PR does some foundational work to move some aspects of table schema creation out of the sink and into external functions which can be called by source, sink, or store, whoever needs it.  This is necessary to write the source.  Also update the store implementation to do schema creation once and pass the table metadata to source/sink, to avoid duplicating work.  The source/sink retain the ability to do this themselves, if they are used independently of the store.