### PR TITLE
Minor fix to certain relational data sink unit tests related to dictionary properties

### DIFF
--- a/stix2/properties.py
+++ b/stix2/properties.py
@@ -504,7 +504,7 @@ class DictionaryProperty(Property):
                     except CustomContentError:
                         # Need to propagate these, not treat as a type error
                         raise
-                    except Exception as e:
+                    except Exception:
                         # clean failed; value must not conform to type_
                         # Should be a narrower exception type here, but I don't
                         # know if it's safe to assume any particular exception

--- a/stix2/test/v21/test_datastore_relational_db.py
+++ b/stix2/test/v21/test_datastore_relational_db.py
@@ -768,9 +768,7 @@ def property_variation_value(request, base_property_value):
 
     elif request.param == "dict-of":
         prop_variation = stix2.properties.DictionaryProperty(
-            # DictionaryProperty.valid_types does not accept property
-            # instances (except ListProperty instances), only classes...
-            valid_types=type(base_property)
+            valid_types=base_property
         )
         # key name doesn't matter here
         prop_variation_value = {"key": prop_value}


### PR DESCRIPTION
... to account for fixes to the relational data sink. Also fix a minor typo in DictionaryProperty where an exception variable was left in by mistake.