### PR TITLE
Fix constraint violation checking for GranularMarking in v21.

### DIFF
--- a/stix2/test/v21/test_markings.py
+++ b/stix2/test/v21/test_markings.py
@@ -175,7 +175,7 @@ def test_granular_marking_mutual_exclusion_error():
         stix2.v21.GranularMarking(
             lang="en",
             marking_ref=stix2.TLP_GREEN,
-            selectors=["foo"]
+            selectors=["foo"],
         )
     assert excinfo.value.cls == stix2.v21.GranularMarking
     assert excinfo.value.properties == ["lang", "marking_ref"]

--- a/stix2/test/v21/test_markings.py
+++ b/stix2/test/v21/test_markings.py
@@ -170,6 +170,18 @@ def test_granular_example_with_bad_selector():
     assert str(excinfo.value) == "Invalid value for GranularMarking 'selectors': must adhere to selector syntax."
 
 
+def test_granular_marking_mutual_exclusion_error():
+    with pytest.raises(stix2.exceptions.MutuallyExclusivePropertiesError) as excinfo:
+        stix2.v21.GranularMarking(
+            lang="en",
+            marking_ref=stix2.TLP_GREEN,
+            selectors=["foo"]
+        )
+    assert excinfo.value.cls == stix2.v21.GranularMarking
+    assert excinfo.value.properties == ["lang", "marking_ref"]
+    assert 'are mutually exclusive' in str(excinfo.value)
+
+
 def test_campaign_with_granular_markings_example():
     campaign = stix2.v21.Campaign(
         id="campaign--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",

--- a/stix2/v21/common.py
+++ b/stix2/v21/common.py
@@ -77,7 +77,7 @@ class GranularMarking(_STIXBase21):
     def _check_object_constraints(self):
         super(GranularMarking, self)._check_object_constraints()
         self._check_at_least_one_property(['lang', 'marking_ref'])
-
+        self._check_mutually_exclusive_properties(['lang', 'marking_ref'])
 
 class LanguageContent(_STIXBase21):
     """For more detailed information on this object's properties, see

--- a/stix2/v21/common.py
+++ b/stix2/v21/common.py
@@ -79,6 +79,7 @@ class GranularMarking(_STIXBase21):
         self._check_at_least_one_property(['lang', 'marking_ref'])
         self._check_mutually_exclusive_properties(['lang', 'marking_ref'])
 
+
 class LanguageContent(_STIXBase21):
     """For more detailed information on this object's properties, see
     `the STIX 2.1 specification <https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_z9r1cwtu8jja>`__.


### PR DESCRIPTION
This PR fixes #586.

- used the `_check_mutually_exclusive_properties` method to catch the exception caused by the incorrect use of both `lang` and `marking_ref` properties in the same time
- added a corresponding unit test case 