### PR TITLE
Skip unallowed common properties provided by ObjectFactory

### DIFF
--- a/stix2/environment.py
+++ b/stix2/environment.py
@@ -83,6 +83,13 @@ class ObjectFactory(object):
         # Use self.defaults as the base, but update with any explicit args
         # provided by the user.
         properties = copy.deepcopy(self._defaults)
+
+        # SCOs do not have these common properties provided by the factory
+        if "observables" in cls.__module__:
+            properties.pop("created", None)
+            properties.pop("created_by_ref", None)
+            properties.pop("external_references", None)
+
         if kwargs:
             if self._list_append:
                 # Append provided items to list properties instead of replacing them


### PR DESCRIPTION
**Problem:** the existing `ObjectFactory` when initialized with the default values like `created_by_ref`, does not handle properly the creation of SCOs, which does not have these default properties (`created`, `created_by_ref`, `external_references`) accordingly to the standard.

![image](https://github.com/user-attachments/assets/84bf46f6-3eb3-4848-992d-e0b901aff7d0)

Test `snippet.py`:
```python
from stix2.environment import ObjectFactory
from stix2.v21 import DomainName, Identity, Malware

identity = Identity(name="Test", description="Test")

factory = ObjectFactory(created_by_ref=identity.id)

malware = factory.create(Malware, name="dridex", is_family=True)
domain = factory.create(DomainName, value="test.com")

print("Malware: ", malware.name)
print("Domain: ", domain.value)
```

**Without** the changes proposed in this pull request:
```
$ python snippet.py 
Traceback (most recent call last):
  File "/openstix-python/src/stix2/snippet.py", line 9, in <module>
    domain = factory.create(DomainName, value="test.com")
  File "/openstix-python/src/stix2/stix2/environment.py", line 104, in create
    return cls(**properties)
  File "/openstix-python/src/stix2/stix2/v21/base.py", line 15, in __init__
    super(_Observable, self).__init__(**kwargs)
  File "/openstix-python/src/stix2/stix2/base.py", line 381, in __init__
    super(_Observable, self).__init__(**kwargs)
  File "/openstix-python/src/stix2/stix2/base.py", line 157, in __init__
    raise ExtraPropertiesError(cls, custom_kwargs)
stix2.exceptions.ExtraPropertiesError: Unexpected properties for DomainName: (created_by_ref).
```

**With** the changes proposed in this pull request:
```
$ python snippet.py 
Malware:  dridex
Domain:  test.com
```