### PR TITLE
Fix for issue #572

### DIFF
--- a/stix2/base.py
+++ b/stix2/base.py
@@ -103,7 +103,8 @@ class _STIXBase(collections.abc.Mapping):
         failed_dependency_pairs = []
         for p in list_of_properties:
             for dp in list_of_dependent_properties:
-                if not self.get(p) and self.get(dp):
+                if self.get(p) is None and self.get(dp) is not None:
+                # if not self.get(p) and self.get(dp):
                     failed_dependency_pairs.append((p, dp))
         if failed_dependency_pairs:
             raise DependentPropertiesError(self.__class__, failed_dependency_pairs)

--- a/stix2/base.py
+++ b/stix2/base.py
@@ -104,7 +104,6 @@ class _STIXBase(collections.abc.Mapping):
         for p in list_of_properties:
             for dp in list_of_dependent_properties:
                 if self.get(p) is None and self.get(dp) is not None:
-                # if not self.get(p) and self.get(dp):
                     failed_dependency_pairs.append((p, dp))
         if failed_dependency_pairs:
             raise DependentPropertiesError(self.__class__, failed_dependency_pairs)

--- a/stix2/test/v21/test_location.py
+++ b/stix2/test/v21/test_location.py
@@ -377,3 +377,45 @@ def test_bing_map_url_multiple_props_and_long_lat_provided():
 
     loc_url = loc.to_maps_url("Bing Maps")
     assert loc_url == expected_url
+
+def test_bing_map_url_for_0_long_lat():
+    expected_url = "https://bing.com/maps/default.aspx?where1=0.0%2C0.0&lvl=16"
+
+    loc = stix2.v21.Location(
+        region="northern-america",
+        country="United States of America",
+        street_address="1410 Museum Campus Drive, Chicago, IL 60605",
+        latitude=0,
+        longitude=-0,
+    )
+
+    loc_url = loc.to_maps_url("Bing Maps")
+    assert loc_url == expected_url
+
+def test_bing_map_url_for_0_long():
+    expected_url = "https://bing.com/maps/default.aspx?where1=0.0%2C-348.2&lvl=16"
+
+    loc = stix2.v21.Location(
+        region="northern-america",
+        country="United States of America",
+        street_address="1410 Museum Campus Drive, Chicago, IL 60605",
+        latitude=0,
+        longitude=-348.2,
+    )
+
+    loc_url = loc.to_maps_url("Bing Maps")
+    assert loc_url == expected_url
+
+def test_bing_map_url_for_0_lat():
+    expected_url = "https://bing.com/maps/default.aspx?where1=84.2%2C0.0&lvl=16"
+
+    loc = stix2.v21.Location(
+        region="northern-america",
+        country="United States of America",
+        street_address="1410 Museum Campus Drive, Chicago, IL 60605",
+        latitude=84.2,
+        longitude=-0,
+    )
+
+    loc_url = loc.to_maps_url("Bing Maps")
+    assert loc_url == expected_url


### PR DESCRIPTION
Issue #572 errors when longitude or latitude has a 0 value. This fix takes into account 0 values for longitude and latitude.