### PR TITLE
Experimental changes to allow relational-data-sink implementation to work with different database backends

### DIFF
--- a/stix2/datastore/relational_db/relational_db.py
+++ b/stix2/datastore/relational_db/relational_db.py
@@ -80,7 +80,41 @@ class RelationalDBStore(DataStoreMixin):
                 auto-detect all classes and create table schemas for all of
                 them.
         """
+
+        # The typical usage of SQLAlchemy's create_engine() function is once per
+        # particular database connection url and held globally for the lifetime of
+        # a single application process. Among the various databases/dialects supported
+        # by SQLAlchemy, this function call appears to work well for the following
+        # three variants using a single url argument as below:
+        #
+        # PostgreSQL:
+        #   url = f"postgresql://{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}@127.0.0.1:5432/rdb"
+        # SQLite:
+        #   url = f"sqlite:///sqlite_rdb.db"
+        # MariaDB:
+        #   url = f"mariadb+pymysql://{os.getenv('MARIADB_USER')}:{os.getenv('MARIADB_PASSWORD')}@127.0.0.1:3306/rdb"
+        #
         database_connection = create_engine(database_connection_url)
+
+        # For MySQL, which happens to use the same default port 3306 as for MariaDB,
+        # we can use a different port so multiple SQL service instances can be running
+        # on the same machine. Below is a workaround for connecting to the MySQL server
+        # at port 3307 using the connect_args dictionary parameter:
+        #
+        # MySQL:
+        #    url = f"mysql+pymysql://os.getenv('MYSQL_USER'):os.getenv('MYSQL_PASSWORD')@127.0.0.1/rdb"
+        #    connect_args = dict(unix_socket="/var/mysql/mysql.sock", port=3307)
+        #
+        # database_connection = create_engine(database_connection_url,
+        #                                    connect_args=dict(unix_socket="/var/mysql/mysql.sock", port=3307))
+
+        # For MS-SQL (TBD):
+        #   server = '127.0.0.1:1433'
+        #   user = os.getenv("PYMSSQL_USERNAME")
+        #   password = os.getenv("PYMSSQL_PASSWORD")
+        #   database = 'rdb'
+        #   database_connection = pymssql.connect(server, user, password, database)
+
         self.metadata = MetaData()
         create_table_objects(
              self.metadata, stix_object_classes,

--- a/stix2/test/v21/test_datastore_relational_db.py
+++ b/stix2/test/v21/test_datastore_relational_db.py
@@ -12,13 +12,27 @@ import stix2.properties
 import stix2.registry
 import stix2.v21
 
-_DB_CONNECT_URL = f"postgresql://{os.getenv('POSTGRES_USER', 'postgres')}:{os.getenv('POSTGRES_PASSWORD', 'postgres')}@0.0.0.0:5432/postgres"
+# PostgreSQL
+#_DB_CONNECT_URL = f"postgresql://{os.getenv('POSTGRES_USER', 'postgres')}:{os.getenv('POSTGRES_PASSWORD', 'postgres')}@127.0.0.1:5432/postgres"
+
+# SQLite
+_DB_CONNECT_URL = f"sqlite:///sqlite_rdb.db"
+
+# MariaDB
+#_DB_CONNECT_URL = f"mariadb+pymysql://{os.getenv('MARIADB_USER')}:{os.getenv('MARIADB_PASSWORD')}@127.0.0.1:3306/rdb"
+
+# MySQL
+#_DB_CONNECT_URL = f"mysql+pymysql://os.getenv('MYSQL_USER'):os.getenv('MYSQL_PASSWORD')@127.0.0.1/rdb"
+
+# MS-SQL (TBD)
+# import pymssql
+# cn = pymssql.connect('127.0.0.1:1433', os.getenv("PYMSSQL_USERNAME"), os.getenv("PYMSSQL_PASSWORD"), 'rdb')
 
 store = RelationalDBStore(
     _DB_CONNECT_URL,
     True,
     None,
-    False
+    True
 )
 
 # Artifacts


### PR DESCRIPTION
Added test code to scope out the work needed to support the following variants:

- SQLite
- MariaDB
- MySQL
- Microsoft SQL (MSSQL)

Testing has been done on a MacBook Pro M3 system for the first three; the corresponding log file is attached for reference. The code for MSSQL remains to be tested, so consider it as a place holder for now.

[sqlite.log](https://github.com/user-attachments/files/17652847/sqlite.log)
[mariadb.log](https://github.com/user-attachments/files/17652850/mariadb.log)
[mysql.log](https://github.com/user-attachments/files/17652853/mysql.log)
