### PR TITLE
relational data source: support db backends, db's which don't support array columns

### DIFF
--- a/stix2/datastore/relational_db/relational_db.py
+++ b/stix2/datastore/relational_db/relational_db.py
@@ -195,10 +195,11 @@ class RelationalDBSource(DataSource):
         Initialize this source.  Only one of stix_object_classes and metadata
         should be given: if the latter is given, assume table schemas are
         already created.  Instances of this class do not create the actual
-        database tables; see the source/sink for that.
+        database tables; see the store/sink for that.
 
         Args:
-            database_connection_or_url: An SQLAlchemy engine object, or URL
+            db_backend: A database backend object
+            allow_custom: TODO: unused so far
             *stix_object_classes: STIX object classes to map into table schemas.
                 This can be used to limit which schemas are created, if one is
                 only working with a subset of STIX types.  If not given,
@@ -230,6 +231,7 @@ class RelationalDBSource(DataSource):
                 stix_id,
                 self.metadata,
                 conn,
+                self.db_backend,
             )
 
         return stix_obj

--- a/stix2/test/v21/test_datastore_relational_db.py
+++ b/stix2/test/v21/test_datastore_relational_db.py
@@ -7,6 +7,9 @@ import pytest
 
 import stix2
 from stix2.datastore import DataSourceError
+from stix2.datastore.relational_db.database_backends.postgres_backend import (
+    PostgresBackend,
+)
 from stix2.datastore.relational_db.relational_db import RelationalDBStore
 import stix2.properties
 import stix2.registry
@@ -15,7 +18,7 @@ import stix2.v21
 _DB_CONNECT_URL = f"postgresql://{os.getenv('POSTGRES_USER', 'postgres')}:{os.getenv('POSTGRES_PASSWORD', 'postgres')}@0.0.0.0:5432/postgres"
 
 store = RelationalDBStore(
-    _DB_CONNECT_URL,
+    PostgresBackend(_DB_CONNECT_URL, True),
     True,
     None,
     False,
@@ -878,7 +881,7 @@ def test_property(object_variation):
     ensure schemas can be created and values can be stored and retrieved.
     """
     rdb_store = RelationalDBStore(
-        _DB_CONNECT_URL,
+        PostgresBackend(_DB_CONNECT_URL, True),
         True,
         None,
         True,
@@ -918,7 +921,7 @@ def test_dictionary_property_complex():
         )
 
         rdb_store = RelationalDBStore(
-            _DB_CONNECT_URL,
+            PostgresBackend(_DB_CONNECT_URL, True),
             True,
             None,
             True,
@@ -934,6 +937,7 @@ def test_dictionary_property_complex():
 def test_extension_definition():
     obj = stix2.ExtensionDefinition(
         created_by_ref="identity--8a5fb7e4-aabe-4635-8972-cbcde1fa4792",
+        labels=["label1", "label2"],
         name="test",
         schema="a schema",
         version="1.2.3",


### PR DESCRIPTION
Add support for db backends and dbs which don't support array column types, to the relational data source