### PR TITLE
handle-hex-better

### DIFF
--- a/stix2/datastore/relational_db/database_backends/database_backend_base.py
+++ b/stix2/datastore/relational_db/database_backends/database_backend_base.py
@@ -105,3 +105,10 @@ class DatabaseBackend:
     @staticmethod
     def array_allowed():
         return False
+
+    def generate_value(self, stix_type, value):
+        sql_type = stix_type.determine_sql_type(self)
+        if sql_type == self.determine_sql_type_for_string_property():
+            return value
+        elif sql_type == self.determine_sql_type_for_hex_property():
+            return bytes.fromhex(value)

--- a/stix2/datastore/relational_db/database_backends/postgres_backend.py
+++ b/stix2/datastore/relational_db/database_backends/postgres_backend.py
@@ -50,11 +50,12 @@ class PostgresBackend(DatabaseBackend):
 
     @staticmethod
     def determine_sql_type_for_binary_property():  # noqa: F811
-        return Text
+        return PostgresBackend.determine_sql_type_for_string_property()
 
     @staticmethod
     def determine_sql_type_for_hex_property():  # noqa: F811
-        return LargeBinary
+        # return LargeBinary
+        return PostgresBackend.determine_sql_type_for_string_property()
 
     @staticmethod
     def determine_sql_type_for_timestamp_property():  # noqa: F811

--- a/stix2/datastore/relational_db/input_creation.py
+++ b/stix2/datastore/relational_db/input_creation.py
@@ -140,9 +140,8 @@ def generate_insert_information(self, name, stix_object, **kwargs):  # noqa: F81
 
 
 @add_method(HexProperty)
-def generate_insert_information(self, name, stix_object, **kwargs):  # noqa: F811
-    v = bytes.fromhex(stix_object[name])
-    return {name: v}
+def generate_insert_information(self, name, stix_object, data_sink, **kwargs):  # noqa: F811
+    return {name: data_sink.db_backend.generate_value(self, stix_object[name])}
 
 
 def generate_insert_for_hashes(
@@ -249,7 +248,7 @@ def generate_insert_information(   # noqa: F811
     else:
         if db_backend.array_allowed():
             if isinstance(self.contained, HexProperty):
-                return {name: [bytes.fromhex(x) for x in stix_object[name]]}
+                return {name: [data_sink.db_backend.generate_value(self.contained, x) for x in stix_object[name]]}
             else:
                 return {name: stix_object[name]}
 


### PR DESCRIPTION
if hex is being stored in the db as a string - don't convert it to bytes