### PR TITLE
adjust datetime str nanoseconds to microseconds

### DIFF
--- a/stix2/test/v21/test_timestamp_precision.py
+++ b/stix2/test/v21/test_timestamp_precision.py
@@ -71,6 +71,11 @@ def test_stix_datetime():
 
 @pytest.mark.parametrize(
     "us, precision, precision_constraint, expected_truncated_us", [
+        (123456789, Precision.ANY, PrecisionConstraint.EXACT, 123456),
+        (123456789, Precision.SECOND, PrecisionConstraint.EXACT, 0),
+        (123456789, Precision.SECOND, PrecisionConstraint.MIN, 123456),
+        (123456789, Precision.MILLISECOND, PrecisionConstraint.EXACT, 123000),
+        (123456789, Precision.MILLISECOND, PrecisionConstraint.MIN, 123456),
         (123456, Precision.ANY, PrecisionConstraint.EXACT, 123456),
         (123456, Precision.SECOND, PrecisionConstraint.EXACT, 0),
         (123456, Precision.SECOND, PrecisionConstraint.MIN, 123456),


### PR DESCRIPTION
This pull request addresses the issue described in [#578](https://github.com/oasis-open/cti-python-stix2/issues/578), where handling of timestamp precision was not correctly adjusted when converting nanoseconds to microseconds.

**Changes made:**
Implemented logic to adjust nanoseconds to microseconds precision when the timestamp has nanoseconds precision (9 digits followed by 'Z').

**Testing:**
Updated unit tests to check for timestamp conversion and precision handling with different values (e.g., second, millisecond, nanosecond).
Validated that timestamp precision is correctly truncated for nanosecond precision when required.