### PR TITLE
Change relational-data-sink class scanning to scan the registry

### DIFF
--- a/stix2/datastore/relational_db/query.py
+++ b/stix2/datastore/relational_db/query.py
@@ -7,6 +7,7 @@ import stix2
 from stix2.datastore import DataSourceError
 from stix2.datastore.relational_db.utils import (
     canonicalize_table_name, schema_for, table_name_for,
+    see_through_workbench,
 )
 import stix2.properties
 import stix2.utils
@@ -67,6 +68,9 @@ def _stix2_class_for(stix_id):
         # TODO: give user control over STIX version used?
         stix_type, stix_version=stix2.DEFAULT_VERSION,
     )
+
+    if stix_class:
+        stix_class = see_through_workbench(stix_class)
 
     return stix_class
 


### PR DESCRIPTION
This simple PR shows the changes I made to class scanning to get unit tests running under tox again.  The unit tests seem to run normally in the github runner now.  They don't all pass though.  This PR doesn't include the fixes to the unit tests; I wanted to have a simple PR which just shows the changes I made to get to the point where we could start addressing individual unit tests.

Class scanning is changed to look at the stix2 lib's registry.  So it will only find classes which have been registered.  I think it's better that way anyway.  I had to hack around the workbench's patching of the registry.  I think most of the time it won't be an issue in practice since probably most people don't use the workbench.  But the unit tests include tests of the workbench, which causes the workbench module to be imported, which is what triggers the registry patching.  So we needed a way to deal with that for unit testing, unfortunately.