### PR TITLE
Fix unit test cleanup bug in relational datastore test suite

### DIFF
--- a/stix2/test/v21/test_datastore_relational_db.py
+++ b/stix2/test/v21/test_datastore_relational_db.py
@@ -687,14 +687,12 @@ def _register_object(*args, **kwargs):
 
     try:
         yield TestClass
-    except:  # noqa: E722
+    finally:
         ext_id = kwargs.get("extension_name")
         if not ext_id and len(args) >= 3:
             ext_id = args[2]
 
         _unregister("objects", TestClass._type, ext_id)
-
-        raise
 
 
 @contextlib.contextmanager
@@ -713,14 +711,12 @@ def _register_observable(*args, **kwargs):
 
     try:
         yield TestClass
-    except:   # noqa: E722
+    finally:
         ext_id = kwargs.get("extension_name")
         if not ext_id and len(args) >= 4:
             ext_id = args[3]
 
         _unregister("observables", TestClass._type, ext_id)
-
-        raise
 
 
 # "Base" properties used to derive property variations for testing (e.g. in a


### PR DESCRIPTION
This fixes my goof where I used a try-except where I should have used a try-finally for a unit test cleanup.  This caused some unit tests to not be properly cleaned up unless an exception occurred, which could cause subsequent unit test failures.