### PR TITLE
Fix test_datastore_add_raises unit tests

### DIFF
--- a/stix2/test/v20/test_datastore.py
+++ b/stix2/test/v20/test_datastore.py
@@ -65,9 +65,8 @@ def test_datastore_related_to_raises():
 
 
 def test_datastore_add_raises():
-    with pytest.raises(AttributeError) as excinfo:
+    with pytest.raises(AttributeError):
         DataStoreMixin().add(CAMPAIGN_MORE_KWARGS)
-    assert "DataStoreMixin has no data sink to put objects in" == str(excinfo.value)
 
 
 def test_composite_datastore_get_raises_error():

--- a/stix2/test/v21/test_datastore.py
+++ b/stix2/test/v21/test_datastore.py
@@ -65,9 +65,8 @@ def test_datastore_related_to_raises():
 
 
 def test_datastore_add_raises():
-    with pytest.raises(AttributeError) as excinfo:
+    with pytest.raises(AttributeError):
         DataStoreMixin().add(CAMPAIGN_MORE_KWARGS)
-    assert "DataStoreMixin has no data sink to put objects in" == str(excinfo.value)
 
 
 def test_composite_datastore_get_raises_error():


### PR DESCRIPTION
DataStoreMixin.add() had been changed to remove a try-except which produced an AttributeError with a special error message.  That broke unit tests which were looking for an AttributeError with that special message.  I just removed the message check.