### PR TITLE
Fix test_environment_no_datastore() unit tests

### DIFF
--- a/stix2/test/v20/test_environment.py
+++ b/stix2/test/v20/test_environment.py
@@ -221,9 +221,8 @@ def test_environment_datastore_and_sink():
 def test_environment_no_datastore():
     env = stix2.Environment(factory=stix2.ObjectFactory())
 
-    with pytest.raises(AttributeError) as excinfo:
+    with pytest.raises(AttributeError):
         env.add(stix2.v20.Indicator(**INDICATOR_KWARGS))
-    assert 'Environment has no data sink to put objects in' in str(excinfo.value)
 
     with pytest.raises(AttributeError) as excinfo:
         env.get(INDICATOR_ID)

--- a/stix2/test/v21/test_environment.py
+++ b/stix2/test/v21/test_environment.py
@@ -230,9 +230,8 @@ def test_environment_datastore_and_sink():
 def test_environment_no_datastore():
     env = stix2.Environment(factory=stix2.ObjectFactory())
 
-    with pytest.raises(AttributeError) as excinfo:
+    with pytest.raises(AttributeError):
         env.add(stix2.v21.Indicator(**INDICATOR_KWARGS))
-    assert 'Environment has no data sink to put objects in' in str(excinfo.value)
 
     with pytest.raises(AttributeError) as excinfo:
         env.get(INDICATOR_ID)


### PR DESCRIPTION
DataStoreMixin.add() had been changed to remove a try-except which produced an AttributeError with a special error message. That broke unit tests which were looking for an AttributeError with that special message. I just removed the message check.